### PR TITLE
gamma: do not make this a constexpr

### DIFF
--- a/loki-b/LoKI-B/Constant.h
+++ b/loki-b/LoKI-B/Constant.h
@@ -49,7 +49,7 @@ constexpr const double Townsend = 1e-21;
  *  below equation (6). Here you find the numerical value of gamma in SI
  *  units, sqrt(C/kg).
  */
-constexpr const double gamma = std::sqrt(2*Constant::electronCharge/Constant::electronMass);
+const double gamma = std::sqrt(2*Constant::electronCharge/Constant::electronMass);
 
 }
 


### PR DESCRIPTION
Fix compilation with clang and emscripten.
As pointed out by @DAANBOER, this requires std::sqrt, which is
not a constexpr function, although g++ marks it as such.