### PR TITLE
Fixed a bug in the eeOperator.

### DIFF
--- a/source/ElectronKinetics.cpp
+++ b/source/ElectronKinetics.cpp
@@ -793,7 +793,7 @@ void ElectronKineticsBoltzmann::solveEEColl()
 
         for (Grid::Index k = 0; k < grid().nCells(); ++k)
         {
-            boltzmannMatrix(k, k) = baseDiag[k] - eeOperator.A[k] + eeOperator.B[k];
+            boltzmannMatrix(k, k) = baseDiag[k] - (eeOperator.A[k] + eeOperator.B[k]);
 
             if (k > 0)
                 boltzmannMatrix(k, k - 1) = baseSubDiag[k] + eeOperator.A[k - 1];


### PR DESCRIPTION
This was introduced in ab231ab6a0a072b689e0095f57fda135c2a1594a and was not caught because my test had a way too low ne value for these collisions to be relevant.