### PR TITLE
Fix name aliasing violations.

### DIFF
--- a/LoKI-B/ElectronKinetics.h
+++ b/LoKI-B/ElectronKinetics.h
@@ -85,7 +85,7 @@ protected:
     {
         return std::log10(std::abs(v1/v2));
     }
-    WorkingConditions *workingConditions;
+    WorkingConditions *m_workingConditions;
 private:
     Grid m_grid;
 protected:

--- a/LoKI-B/Gas.h
+++ b/LoKI-B/Gas.h
@@ -177,7 +177,7 @@ class lokib_export Gas
     {
         auto *state = get_root().ensure_state(entry);
         // state is now a 'charge state' (container)
-        for (uint8_t lvl = StateType::charge; lvl < entry.level; ++lvl)
+        for (uint8_t lvl = StateType::charge; lvl < entry.m_level; ++lvl)
         {
             state = state->ensure_state(entry);
         }
@@ -192,11 +192,13 @@ class lokib_export Gas
     {
         return *m_root;
     }
+    const std::string& name() const { return m_name; }
 
-  public:
+  private:
     std::unique_ptr<State> m_root;
 
-    const std::string name;
+    const std::string m_name;
+  public:
     double mass;
     double harmonicFrequency;
     double anharmonicFrequency;

--- a/LoKI-B/GasMixture.h
+++ b/LoKI-B/GasMixture.h
@@ -42,10 +42,10 @@ void readGasPropertyFile(const GasListType& gasList,
               + "', using file '" + fileName + "'.");
         for (auto &gas : gasList)
         {
-            if (gas->name == "e")
+            if (gas->name() == "e")
                 continue;
             double value;
-            const std::regex r(R"((?:^|\n))" + gas->name + R"(\s+(\S*)\s*)");
+            const std::regex r(R"((?:^|\n))" + gas->name() + R"(\s+(\S*)\s*)");
             std::smatch m;
             if (std::regex_search(fileBuffer, m, r) && Parse::getValue(m[1],value))
             {
@@ -54,9 +54,9 @@ void readGasPropertyFile(const GasListType& gasList,
             else
             {
                 if (required)
-                    Log<GasPropertyError>::Error(propertyName + " in gas " + gas->name);
+                    Log<GasPropertyError>::Error(propertyName + " in gas " + gas->name());
                 else
-                    Log<GasPropertyError>::Warning(propertyName + " in gas " + gas->name);
+                    Log<GasPropertyError>::Warning(propertyName + " in gas " + gas->name());
             }
         }
     }
@@ -91,12 +91,12 @@ void readGasPropertyJson(const GasListType& gasList,
     Log<Message>::Notify("Configuring gas property '" + propertyName + "'.");
     for (auto &gas : gasList)
     {
-        if (gas->name == "e")
+        if (gas->name() == "e")
             continue;
 		bool found = false;
         for (auto& el : cnf)
 	{
-            if (el.at("name") == gas->name)
+            if (el.at("name") == gas->name())
             {
                 found = true;
                 handler(*gas, el.at(propertyName).get<double>());
@@ -105,9 +105,9 @@ void readGasPropertyJson(const GasListType& gasList,
         if (!found)
         {
             if (required)
-                Log<GasPropertyError>::Error(propertyName + " in gas " + gas->name);
+                Log<GasPropertyError>::Error(propertyName + " in gas " + gas->name());
             else
-                Log<GasPropertyError>::Warning(propertyName + " in gas " + gas->name);
+                Log<GasPropertyError>::Warning(propertyName + " in gas " + gas->name());
         }
     }
 }

--- a/LoKI-B/Output.h
+++ b/LoKI-B/Output.h
@@ -39,7 +39,7 @@ protected:
     virtual void writeRateCoefficients(const std::vector<RateCoefficient> &rateCoefficients,
                                const std::vector<RateCoefficient> &extraRateCoefficients) const=0;
     virtual void writeLookuptable(const Power &power, const SwarmParameters &swarmParameters) const=0;
-    const WorkingConditions *workingConditions;
+    const WorkingConditions *m_workingConditions;
 private:
     bool saveEedf, savePower, saveSwarm, saveRates, saveTable;
 };

--- a/LoKI-B/PropertyFunctions.h
+++ b/LoKI-B/PropertyFunctions.h
@@ -93,7 +93,7 @@ inline void harmonicOscillatorEnergy(const std::vector<Gas::State *> &states,
         Log<Message>::Error("Trying to assign harmonic oscillator energy to non-vibrational state.");
 
     if (states.at(0)->gas().harmonicFrequency < 0)
-        Log<Message>::Error("Cannot find harmonicFrequency of the gas " + states.at(0)->gas().name +
+        Log<Message>::Error("Cannot find harmonicFrequency of the gas " + states.at(0)->gas().name() +
                             " to evaluate state energies.");
 
     for (auto *state : states)
@@ -121,7 +121,7 @@ inline void rigidRotorEnergy(const std::vector<Gas::State *> &states, const std:
         Log<Message>::Error("Trying to assign rigid rotor energy to non-rotational state.");
 
     if (states.at(0)->gas().rotationalConstant < 0)
-        Log<Message>::Error("Cannot find rotationalConstant of the gas " + states.at(0)->gas().name +
+        Log<Message>::Error("Cannot find rotationalConstant of the gas " + states.at(0)->gas().name() +
                             " to evaluate state energies.");
 
     for (auto *state : states)

--- a/LoKI-B/StateEntry.h
+++ b/LoKI-B/StateEntry.h
@@ -35,8 +35,8 @@ class lokib_export StateEntry
      *        also to intermediate states in a reliable way?
      */
     const std::string m_id;
-    StateType level;
-    std::string charge, gasName, e, v, J;
+    const StateType m_level;
+    const std::string m_gasName, m_charge, m_e, m_v, m_J;
 };
 
 lokib_export std::ostream& operator<<(std::ostream &os, const StateEntry &entry);

--- a/source/EedfCollisions.cpp
+++ b/source/EedfCollisions.cpp
@@ -54,7 +54,7 @@ VectorType remove_electron_entries(const Collision::StateVector &parts, const Ve
     // beware of iterator invalidation
     for (unsigned i = 0; i != parts.size(); ++i)
     {
-        if (parts[i]->gas().name != "e")
+        if (parts[i]->gas().name() != "e")
         {
             result.push_back(vec[i]);
         }
@@ -75,8 +75,8 @@ EedfCollision::EedfCollision(CollisionType type, const StateVector &lhsStates, c
     // for the left hand side we expect 'e + X' or 'X + e'.
     assert(lhsStates.size() == lhsCoeffs.size());
     if (lhsStates.size() != 2 || lhsCoeffs[0] != 1 || lhsCoeffs[1] != 1 ||
-        (lhsStates[0]->gas().name == "e" && lhsStates[1]->gas().name == "e") ||
-        (lhsStates[0]->gas().name != "e" && lhsStates[1]->gas().name != "e"))
+        (lhsStates[0]->gas().name() == "e" && lhsStates[1]->gas().name() == "e") ||
+        (lhsStates[0]->gas().name() != "e" && lhsStates[1]->gas().name() != "e"))
     {
         Log<Message>::Error("Expected a binary electron impact process.");
     }
@@ -404,7 +404,7 @@ CrossSection *EedfCollisionDataGas::elasticCrossSectionFromEffective(const Grid 
      *  is specified? Is that an input error? The code below only uses the first.
      */
     if (collisions(CollisionType::effective).empty())
-        Log<Message>::Error("Could not find effective cross section for gas " + m_gas.name + ".");
+        Log<Message>::Error("Could not find effective cross section for gas " + m_gas.name() + ".");
 
     EedfCollision *eff = collisions(CollisionType::effective)[0].get();
     const Vector &rawEnergies = eff->crossSection->lookupTable().x();
@@ -452,7 +452,7 @@ CrossSection *EedfCollisionDataGas::elasticCrossSectionFromEffective(const Grid 
     }
 
     if (warn)
-        Log<NegativeElastic>::Warning(m_gas.name);
+        Log<NegativeElastic>::Warning(m_gas.name());
 
     return new CrossSection(0., energyGrid, true, rawEnergies, rawEl);
 }
@@ -841,7 +841,7 @@ const EedfCollisionDataGas &EedfCollisionDataMixture::get_data_for(const Gas &ga
             return cd;
         }
     }
-    throw std::runtime_error("Could not find per-gas collision data for '" + gas.name + "'.");
+    throw std::runtime_error("Could not find per-gas collision data for '" + gas.name() + "'.");
 }
 
 EedfCollisionDataGas &EedfCollisionDataMixture::get_data_for(const Gas &gas)

--- a/source/Gas.cpp
+++ b/source/Gas.cpp
@@ -10,9 +10,9 @@ namespace loki
 
 Gas::State::State(const StateEntry &entry, Gas *gas, State &parent)
     : m_gas(gas), m_parent(&parent), type(static_cast<StateType>(parent.type + 1)),
-      charge(type == StateType::charge ? entry.charge : parent.charge),
-      e(type == StateType::electronic ? entry.e : parent.e), v(type == StateType::vibrational ? entry.v : parent.v),
-      J(type == StateType::rotational ? entry.J : parent.J), energy(-1), statisticalWeight(-1),
+      charge(type == StateType::charge ? entry.m_charge : parent.charge),
+      e(type == StateType::electronic ? entry.m_e : parent.e), v(type == StateType::vibrational ? entry.m_v : parent.v),
+      J(type == StateType::rotational ? entry.m_J : parent.J), energy(-1), statisticalWeight(-1),
       m_population(0),
       m_delta(0)
 {
@@ -66,10 +66,10 @@ Gas::State::~State()
 
 bool Gas::State::operator>=(const StateEntry &entry)
 {
-    if (type > entry.level)
+    if (type > entry.m_level)
         return false;
 
-    if (charge == entry.charge)
+    if (charge == entry.m_charge)
     {
         if (type == StateType::charge)
             return true;
@@ -78,7 +78,7 @@ bool Gas::State::operator>=(const StateEntry &entry)
     {
         return false;
     }
-    if (e == entry.e)
+    if (e == entry.m_e)
     {
         if (type == StateType::electronic)
             return true;
@@ -88,7 +88,7 @@ bool Gas::State::operator>=(const StateEntry &entry)
         return false;
     }
 
-    if (v == entry.v)
+    if (v == entry.m_v)
     {
         if (type == StateType::vibrational)
             return true;
@@ -98,7 +98,7 @@ bool Gas::State::operator>=(const StateEntry &entry)
         return false;
     }
 
-    if (J == entry.J)
+    if (J == entry.m_J)
     {
         if (type == StateType::rotational)
             return true;
@@ -113,7 +113,7 @@ bool Gas::State::operator>=(const StateEntry &entry)
 
 std::ostream &operator<<(std::ostream &os, const Gas::State &state)
 {
-    os << state.gas().name;
+    os << state.gas().name();
 #if 0
     // write N2+(...) instead of N2(+,...) ?
     /// \todo this does not work: when reading legacy input, the charge is smth. like '+', not a number.
@@ -126,7 +126,7 @@ std::ostream &operator<<(std::ostream &os, const Gas::State &state)
 
     // the electron is handled specially. The logic here is the same as
     // for in StateEntry's stream insertion operator.
-    if (state.gas().name == "e")
+    if (state.gas().name() == "e")
     {
         return os;
     }
@@ -217,7 +217,7 @@ Gas::State *Gas::State::find(const StateEntry &entry)
 }
 
 Gas::Gas(std::string name)
-    : m_root(new State(this)), name{name}, mass{-1}, harmonicFrequency{-1}, anharmonicFrequency{-1},
+    : m_root(new State(this)), m_name{name}, mass{-1}, harmonicFrequency{-1}, anharmonicFrequency{-1},
       rotationalConstant{-1}, electricDipoleMoment{-1}, electricQuadrupoleMoment{-1}, polarizability{-1}, fraction{0}
 {
 }
@@ -266,10 +266,10 @@ Gas::State *Gas::findState(const StateEntry &entry)
     if (state == nullptr)
         return nullptr;
 
-    if (entry.level == charge)
+    if (entry.m_level == charge)
         return state;
 
-    if (entry.e == "*" && entry.level == electronic)
+    if (entry.m_e == "*" && entry.m_level == electronic)
     {
         if (state->m_children.empty())
             return nullptr;
@@ -284,10 +284,10 @@ Gas::State *Gas::findState(const StateEntry &entry)
     if (state == nullptr)
         return nullptr;
 
-    if (entry.level == electronic)
+    if (entry.m_level == electronic)
         return state;
 
-    if (entry.v == "*" && entry.level == vibrational)
+    if (entry.m_v == "*" && entry.m_level == vibrational)
     {
         if (state->m_children.empty())
             return nullptr;
@@ -302,10 +302,10 @@ Gas::State *Gas::findState(const StateEntry &entry)
     if (state == nullptr)
         return nullptr;
 
-    if (entry.level == vibrational)
+    if (entry.m_level == vibrational)
         return state;
 
-    if (entry.J == "*" && entry.level == rotational)
+    if (entry.m_J == "*" && entry.m_level == rotational)
     {
         if (state->m_children.empty())
             return nullptr;
@@ -320,7 +320,7 @@ Gas::State *Gas::findState(const StateEntry &entry)
     if (state == nullptr)
         return nullptr;
 
-    if (entry.level == rotational)
+    if (entry.m_level == rotational)
         return state;
 
     return nullptr;

--- a/source/GasMixture.cpp
+++ b/source/GasMixture.cpp
@@ -40,7 +40,7 @@ Gas::State *GasMixture::ensureState(const StateEntry &entry)
     {
         return it->second;
     }
-    Gas::State *state = ensureGas(entry.gasName)->ensureState(entry);
+    Gas::State *state = ensureGas(entry.m_gasName)->ensureState(entry);
     m_states[entry.m_id] = state;
     return state;
 }
@@ -54,7 +54,7 @@ void GasMixture::print(std::ostream &os)
 {
     for (const auto &gas : m_gases)
     {
-        os << "Gas: " << gas->name << std::endl;
+        os << "Gas: " << gas->name() << std::endl;
         gas->print(os);
     }
 }
@@ -81,13 +81,13 @@ void GasMixture::checkPopulations()
 Gas *GasMixture::findGas(const std::string &name)
 {
     auto it = std::find_if(m_gases.begin(), m_gases.end(),
-                           [&name](const std::unique_ptr<Gas> &gas) { return gas->name == name; });
+                           [&name](const std::unique_ptr<Gas> &gas) { return gas->name() == name; });
     return it == m_gases.end() ? nullptr : it->get();
 }
 
 Gas::State *GasMixture::findState(const StateEntry &entry)
 {
-    Gas *gas = findGas(entry.gasName);
+    Gas *gas = findGas(entry.m_gasName);
     return gas ? gas->findState(entry) : nullptr;
 }
 
@@ -120,7 +120,7 @@ void GasMixture::loadStateProperty(const std::vector<std::string> &entryVector, 
             /** \todo Should this be part of propertyStateFromString?
              *        Is there a reason to accept a 'none'-result?
              */
-            if (entry.level == none)
+            if (entry.m_level == none)
             {
                 throw std::runtime_error("loadStateProperty: illegal "
                                 "state identifier '" + line + "'.");
@@ -269,7 +269,7 @@ void GasMixture::loadGasProperties(const GasPropertiesSetup &setup)
         const auto &name = m.str(1);
 
         auto it = std::find_if(m_gases.begin(), m_gases.end(),
-                               [&name](std::unique_ptr<Gas> &gas) { return (gas->name == name); });
+                               [&name](std::unique_ptr<Gas> &gas) { return (gas->name() == name); });
 
         if (it == m_gases.end())
             Log<Message>::Error("Trying to set fraction for non-existent gas: " + name + '.');
@@ -306,7 +306,7 @@ void GasMixture::loadGasProperties(const json_type &cnf)
             Log<Message>::Error("Could not parse gas fractions.");
         const auto &name = m.str(1);
         auto it = std::find_if(m_gases.begin(), m_gases.end(),
-                               [&name](std::unique_ptr<Gas> &gas) { return (gas->name == name); });
+                               [&name](std::unique_ptr<Gas> &gas) { return (gas->name() == name); });
         if (it == m_gases.end())
             Log<Message>::Error("Trying to set fraction for non-existent gas: " + name + '.');
         std::stringstream ss(m.str(2));

--- a/source/JobSystem.cpp
+++ b/source/JobSystem.cpp
@@ -75,7 +75,7 @@ class RangeSingleValue : public Range
 class RangeLinSpace : public Range
 {
   public:
-    RangeLinSpace(double start, double stop, size_type size) : Range(size), start(start), stop(stop)
+    RangeLinSpace(double start, double stop, size_type size) : Range(size), m_start(start), m_stop(stop)
     {
         Log<Message>::Notify("Creating linspace range"
                              ", start = ",
@@ -89,12 +89,12 @@ class RangeLinSpace : public Range
   protected:
     virtual double get_value(size_type ndx) const override
     {
-        return start + ndx * (stop - start) / (size() - 1);
+        return m_start + ndx * (m_stop - m_start) / (size() - 1);
     }
 
   private:
-    const double start;
-    const double stop;
+    const double m_start;
+    const double m_stop;
 };
 
 /** A range that represents a 'logspace', the values are obtained as
@@ -105,7 +105,7 @@ class RangeLogSpace : public Range
 {
   public:
     RangeLogSpace(double log_start, double log_stop, size_type size)
-        : Range(size), log_start(log_start), log_stop(log_stop)
+        : Range(size), m_log_start(log_start), m_log_stop(log_stop)
     {
         Log<Message>::Notify("Creating logspace range"
                              ", log_start = ",
@@ -119,13 +119,13 @@ class RangeLogSpace : public Range
   protected:
     virtual double get_value(size_type ndx) const override
     {
-        const double log_value = log_start + ndx * (log_stop - log_start) / (size() - 1);
+        const double log_value = m_log_start + ndx * (m_log_stop - m_log_start) / (size() - 1);
         return std::pow(10., log_value);
     }
 
   private:
-    const double log_start;
-    const double log_stop;
+    const double m_log_start;
+    const double m_log_stop;
 };
 
 /** A range that represents an array of predefined values.

--- a/source/Output.cpp
+++ b/source/Output.cpp
@@ -21,7 +21,7 @@ Output::~Output()
 }
 
 Output::Output(const Setup &s, const WorkingConditions *workingConditions)
-    : workingConditions(workingConditions)
+    : m_workingConditions(workingConditions)
 {
     saveEedf = false;
     savePower = false;
@@ -55,7 +55,7 @@ Output::Output(const Setup &s, const WorkingConditions *workingConditions)
 }
 
 Output::Output(const json_type &cnf, const WorkingConditions *workingConditions)
-    : workingConditions(workingConditions)
+    : m_workingConditions(workingConditions)
 {
     saveEedf = false;
     savePower = false;
@@ -164,7 +164,7 @@ void FileOutput::writeEedf(const Vector &eedf, const Vector *firstAnisotropy, co
 void FileOutput::writeSwarm(const SwarmParameters &swarmParameters) const
 {
     std::ofstream os(m_folder + "/" + m_subFolder + "/swarm_parameters.txt");
-    writeTerm(os,"Reduced electric field", "Td", workingConditions->reducedField());
+    writeTerm(os,"Reduced electric field", "Td", m_workingConditions->reducedField());
     writeTerm(os,"Reduced diffusion coefficient","1/(ms)",swarmParameters.redDiffCoeff);
     writeTerm(os,"Reduced mobility coefficient","1/(msV)",swarmParameters.redMobCoeff);
     writeTerm(os,"Reduced Townsend coefficient","m2",swarmParameters.redTownsendCoeff);
@@ -223,7 +223,7 @@ void FileOutput::writePower(const Power &power, const EedfCollisionDataMixture& 
         const GasPower &gasPower = cd.getPower();
 
         os << std::endl;
-        os << std::string(37,'*') << ' ' << cd.gas().name << ' ' << std::string(39 - cd.gas().name.length(),'*') << std::endl;
+        os << std::string(37,'*') << ' ' << cd.gas().name() << ' ' << std::string(39 - cd.gas().name().length(),'*') << std::endl;
         os << std::endl;
 
         writeTerm(os,"Excitation inelastic collisions","eVm3/s", gasPower.excitation.forward);
@@ -285,7 +285,7 @@ void FileOutput::writeLookuptable(const Power &power, const SwarmParameters &swa
                       "DriftVelocity(m/s)   RelativePowerBalance" << std::endl;
         m_initTable = false;
     }
-    os << std::setw(20) << std::scientific << std::setprecision(14) << workingConditions->reducedField();
+    os << std::setw(20) << std::scientific << std::setprecision(14) << m_workingConditions->reducedField();
     os << ' ';
     os << std::setw(20) << std::scientific << std::setprecision(14) << swarmParameters.redDiffCoeff;
     os << ' ';
@@ -385,7 +385,7 @@ void JsonOutput::writeEedf(const Vector &eedf, const Vector *firstAnisotropy, co
 void JsonOutput::writeSwarm(const SwarmParameters &swarmParameters) const
 {
     json_type& out = (*m_active)["swarm_parameters"];
-    out.push_back( makeQuantity("Reduced electric field", workingConditions->reducedField(), "Td") );
+    out.push_back( makeQuantity("Reduced electric field", m_workingConditions->reducedField(), "Td") );
     out.push_back( makeQuantity("Reduced diffusion coefficient", swarmParameters.redDiffCoeff, "1/(m*s)") );
     out.push_back( makeQuantity("Reduced mobility coefficient", swarmParameters.redMobCoeff, "1/(m*s*V)") );
     out.push_back( makeQuantity("Reduced Townsend coefficient", swarmParameters.redTownsendCoeff, "m^2") );
@@ -442,7 +442,7 @@ void JsonOutput::writePower(const Power &power, const EedfCollisionDataMixture& 
     {
         const GasPower &gasPower = cd.getPower();
 	json_type gas_out;
-        gas_out.push_back( { { "name", cd.gas().name } } );
+        gas_out.push_back( { { "name", cd.gas().name() } } );
         gas_out.push_back( makeQuantity("Excitation inelastic collisions", gasPower.excitation.forward, "eV*m^3/s") );
         gas_out.push_back( makeQuantity("Excitation superelastic collisions", gasPower.excitation.backward, "eV*m^3/s") );
         gas_out.push_back( makeQuantity("Excitation collisions (net)", gasPower.excitation.net(), "eV*m^3/s") );
@@ -510,7 +510,7 @@ void JsonOutput::writeLookuptable(const Power &power, const SwarmParameters &swa
     assert(out);
 
     (*out)["data"].push_back( {
-            workingConditions->reducedField(),
+            m_workingConditions->reducedField(),
             swarmParameters.redDiffCoeff,
             swarmParameters.redMobCoeff,
             swarmParameters.redTownsendCoeff,

--- a/source/StateEntry.cpp
+++ b/source/StateEntry.cpp
@@ -15,27 +15,27 @@ StateEntry StateEntry::electronEntry()
     return el;
 }
 
-StateEntry::StateEntry() : m_id{std::string{}}, level(none)
+StateEntry::StateEntry() : m_id{std::string{}}, m_level(none)
 {
 }
 
 StateEntry::StateEntry(const std::string &id, StateType level, const std::string &gasName, const std::string &charge,
                        const std::string &e, const std::string &v, const std::string &J)
-    : m_id(id), level(level), charge(charge), gasName(gasName), e(e), v(v), J(J)
+    : m_id(id), m_level(level), m_gasName(gasName), m_charge(charge), m_e(e), m_v(v), m_J(J)
 {
 }
 
 /// \todo Update: charge may also be a wildcard (?)
 bool StateEntry::hasWildCard() const
 {
-    switch (level)
+    switch (m_level)
     {
     case electronic:
-        return (e == "*");
+        return (m_e == "*");
     case vibrational:
-        return (v == "*");
+        return (m_v == "*");
     case rotational:
-        return (J == "*");
+        return (m_J == "*");
     case none:
         return false;
     default:
@@ -47,19 +47,19 @@ bool StateEntry::hasWildCard() const
 std::ostream &operator<<(std::ostream &os, const StateEntry &entry)
 {
     // special handling of the electron. Just write "e".
-    if (entry.gasName == "e")
+    if (entry.m_gasName == "e")
     {
-        os << entry.gasName;
+        os << entry.m_gasName;
         return os;
     }
-    os << entry.gasName << '(';
-    if (!entry.charge.empty())
-        os << entry.charge << ',';
-    os << entry.e;
-    if (!entry.v.empty())
-        os << ",v=" << entry.v;
-    if (!entry.J.empty())
-        os << ",J=" << entry.J;
+    os << entry.m_gasName << '(';
+    if (!entry.m_charge.empty())
+        os << entry.m_charge << ',';
+    os << entry.m_e;
+    if (!entry.m_v.empty())
+        os << ",v=" << entry.m_v;
+    if (!entry.m_J.empty())
+        os << ",J=" << entry.m_J;
     os << ')';
 
     return os;

--- a/tests/test_reaction_format.cpp
+++ b/tests/test_reaction_format.cpp
@@ -12,7 +12,7 @@ bool test_parser(const std::string stateString)
         assert(entries.size()==stoiCoeff.size());
         for (std::size_t ndx=0; ndx!=entries.size(); ++ndx)
         {
-            std::cout << " - " << stoiCoeff[ndx] << '\t' << entries[ndx] << ", type = " << entries[ndx].level << std::endl;
+            std::cout << " - " << stoiCoeff[ndx] << '\t' << entries[ndx] << ", type = " << entries[ndx].m_level << std::endl;
         }
         return true;
     }

--- a/tests/test_statebase.cpp
+++ b/tests/test_statebase.cpp
@@ -22,7 +22,7 @@ void test_state_string(const std::string str, bool should_pass)
 //        std::cout << "State string: '" << str << "'." << std::endl;
         const StateEntry e = propertyStateFromString(str);
 //        std::cout << "Entry: '" << e << "." << std::endl;
-        loki::Gas gas(e.gasName);
+        loki::Gas gas(e.m_gasName);
 //        std::cout << "Gas name: '" << gas.name << "'." << std::endl;
         const Gas::State root{&gas};
 //        const Gas::State* s{gas.ensureState(e)};


### PR DESCRIPTION
In classes ElectronKinetics, Gas, GasMixture, JobSystem and StateEntry, prefix those data members with m_ where the old names resulted in name aliasing violations (e.g. because the same name was also used as constructor argument).