### PR TITLE
Update note on an error in BOLSIG+ in the ion. ops

### DIFF
--- a/doc/notes/cpp_notes.tex
+++ b/doc/notes/cpp_notes.tex
@@ -1194,6 +1194,7 @@ matrices.
 \end{framed}
 
 
+
 \chapter{Collisional Source Terms}
 \label{ch:sources}
 
@@ -2682,12 +2683,9 @@ Also note that $\gamma u\sigma(u)f^0(u)=\sigma(u)v(u)\sqrt{u}f^0(u):=K(u)\sqrt{u
 with $K(u)$ the energy-dependent rate coefficient. Multiplying that rate coefficient
 with $\sqrt{u}f^0(u)$ and integrating over $u$ yields its average value.
 
-\begin{framed}
 Note that the expression for the source in the BOLSIG+ paper \cite[eq. 29]{Hagelaar2005}
-is different --- it has a factor 2 instead of 4. That appears to be wrong. Note that
-the calculation of the ionization rate coefficient would yield zero for that expression,
-instead of the expected result.
-\end{framed}
+erroneously contains a factor 2 instead of 4. This is pointed out in a footnote on page 23
+of \cite{Hagelaar2008}.
 
 \chapter{Old Notes on LoKI-B 1.0.0}
 


### PR DESCRIPTION
The existence of an erratum was pointed out by Gerjan Hagelaar.