### PR TITLE
use filesystem::path for more filename-strings

### DIFF
--- a/LoKI-B/EedfCollisions.h
+++ b/LoKI-B/EedfCollisions.h
@@ -40,6 +40,7 @@
 #include "LoKI-B/Grid.h"
 #include "LoKI-B/Power.h"
 
+#include <filesystem>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -158,7 +159,7 @@ public:
      *  storage of the collisions.
      *  \todo Explain isExtra.
      */
-    void loadCollisionsClassic(const std::string &file, GasMixture& composition, const Grid *energyGrid, bool isExtra);
+    void loadCollisionsClassic(const std::filesystem::path &file, GasMixture& composition, const Grid *energyGrid, bool isExtra);
 
     /** Loads the collisions from a json mixture section. Such section must contain two
      *  subsections: an object "states" that consists of key-value pairs that represent

--- a/LoKI-B/Parse.h
+++ b/LoKI-B/Parse.h
@@ -32,6 +32,7 @@
 #include "LoKI-B/Exports.h"
 #include <string>
 #include <iosfwd>
+#include <filesystem>
 
 namespace loki {
 namespace Parse {
@@ -121,7 +122,7 @@ lokib_export bool removeComments(std::istream& is, std::string &dest);
  *  \author Daan Boer and Jan van Dijk
  *  \date   November 2020
  */
-lokib_export bool stringBufferFromFile(const std::string &fileName, std::string &dest);
+lokib_export bool stringBufferFromFile(const std::filesystem::path &fileName, std::string &dest);
 
 } // namespace Parse
 } // namespace loki

--- a/LoKI-B/StateEntry.h
+++ b/LoKI-B/StateEntry.h
@@ -5,6 +5,7 @@
 #ifndef LOKI_CPP_STATEENTRY_H
 #define LOKI_CPP_STATEENTRY_H
 
+#include <filesystem>
 #include <ostream>
 #include <set>
 #include <string>
@@ -62,7 +63,7 @@ lokib_export StateEntry propertyStateFromString(const std::string &propertyStrin
 /** Parses state property file \a fileName into \a entries, a vector of
  *  StateEntry/double pairs.
  */
-lokib_export void statePropertyFile(const std::string &fileName, std::vector<std::pair<StateEntry, double>> &entries);
+lokib_export void statePropertyFile(const std::filesystem::path &fileName, std::vector<std::pair<StateEntry, double>> &entries);
 
 } // namespace loki
 

--- a/LoKI-B/json.h
+++ b/LoKI-B/json.h
@@ -5,6 +5,7 @@
 
 #include <nlohmann/json.hpp>
 #include "LoKI-B/Exports.h"
+#include <filesystem>
 #include <iostream>
 #include <string>
 
@@ -14,7 +15,7 @@ namespace loki
 using json_type = nlohmann::json;
 
 lokib_export json_type read_json_from_stream(std::istream &is);
-lokib_export json_type read_json_from_file(const std::string &fname);
+lokib_export json_type read_json_from_file(const std::filesystem::path &fname);
 
 } // namespace loki
 

--- a/source/EedfCollisions.cpp
+++ b/source/EedfCollisions.cpp
@@ -718,7 +718,7 @@ EedfCollisionDataMixture::State *EedfCollisionDataMixture::ensureState(GasMixtur
     return state;
 }
 
-void EedfCollisionDataMixture::loadCollisionsClassic(const std::string &file, GasMixture &composition, const Grid *energyGrid,
+void EedfCollisionDataMixture::loadCollisionsClassic(const std::filesystem::path &file, GasMixture& composition, const Grid *energyGrid,
                                                      bool isExtra)
 {
     const std::regex reParam(R"(PARAM\.:)");
@@ -730,7 +730,7 @@ void EedfCollisionDataMixture::loadCollisionsClassic(const std::string &file, Ga
     std::ifstream in(file);
     if (!in.is_open())
     {
-        Log<FileError>::Warning(file);
+        Log<FileError>::Warning(file.generic_string());
         return;
     }
 
@@ -763,7 +763,7 @@ void EedfCollisionDataMixture::loadCollisionsClassic(const std::string &file, Ga
             }
             if (!std::getline(in, line) || !std::regex_search(line, mProcess, reProcess))
             {
-                Log<LXCatError>::Error(file);
+                Log<LXCatError>::Error(file.generic_string());
             }
 
             try

--- a/source/Parse.cpp
+++ b/source/Parse.cpp
@@ -105,7 +105,7 @@ bool removeComments(std::istream& is, std::string &dest)
     return true;
 }
 
-bool stringBufferFromFile(const std::string &fileName, std::string &dest)
+bool stringBufferFromFile(const std::filesystem::path &fileName, std::string &dest)
 {
     std::ifstream is(fileName);
     return is && removeComments(is,dest);

--- a/source/StateEntry.cpp
+++ b/source/StateEntry.cpp
@@ -360,7 +360,7 @@ StateEntry propertyStateFromString(const std::string &propertyString)
     return {m.str(0), stateType, m.str(1), m.str(2), m.str(3), m.str(4), m.str(5)};
 }
 
-void statePropertyFile(const std::string &fileName, std::vector<std::pair<StateEntry, double>> &entries)
+void statePropertyFile(const std::filesystem::path &fileName, std::vector<std::pair<StateEntry, double>> &entries)
 {
     /** \bug 'S 1.2.3' will be accepted by this regex. Subsequently,
      *        getValue will result in the value 1.2, since that does
@@ -371,7 +371,7 @@ void statePropertyFile(const std::string &fileName, std::vector<std::pair<StateE
     std::string fileBuffer;
     if (!Parse::stringBufferFromFile(fileName, fileBuffer))
     {
-        Log<Message>::Error("Could not open state property file '" + fileName + "' for reading.");
+        Log<Message>::Error("Could not open state property file '" + fileName.generic_string() + "' for reading.");
     }
     std::stringstream ss{fileBuffer};
     std::string line;
@@ -384,7 +384,7 @@ void statePropertyFile(const std::string &fileName, std::vector<std::pair<StateE
         std::smatch m;
         if (!std::regex_search(line, m, expr))
         {
-            throw std::runtime_error("Syntax error in file '" + fileName + "', line '" + line +
+            throw std::runtime_error("Syntax error in file '" + fileName.generic_string() + "', line '" + line +
                                      "': expected a state name and a numeric argument.");
         }
         const std::string stateString = m.str(1);
@@ -392,7 +392,7 @@ void statePropertyFile(const std::string &fileName, std::vector<std::pair<StateE
         double value;
         if (!Parse::getValue(valueString, value))
         {
-            throw std::runtime_error("Syntax error in file '" + fileName + "', line '" + line +
+            throw std::runtime_error("Syntax error in file '" + fileName.generic_string() + "', line '" + line +
                                      "': could not convert argument '" + valueString + "' to a number.");
         }
         entries.emplace_back(propertyStateFromString(stateString), value);

--- a/source/json.cpp
+++ b/source/json.cpp
@@ -13,12 +13,12 @@ json_type read_json_from_stream(std::istream &is)
     return json_type::parse(str);
 }
 
-json_type read_json_from_file(const std::string &fname)
+json_type read_json_from_file(const std::filesystem::path &fname)
 {
     std::ifstream is(fname);
     if (!is)
     {
-        Log<Message>::Error("Could not open file '", fname, "' for reading.");
+        Log<Message>::Error("Could not open file '", fname.generic_string(), "' for reading.");
     }
     try
     {
@@ -26,7 +26,7 @@ json_type read_json_from_file(const std::string &fname)
     }
     catch (std::exception &exc)
     {
-        throw std::runtime_error("Error reading file '" + fname + "':\n" + std::string(exc.what()));
+        throw std::runtime_error("Error reading file '" + fname.generic_string() + "':\n" + std::string(exc.what()));
     }
 }
 


### PR DESCRIPTION
This is more consistent, and solves a compilation problem on MXE, where the path's operator string() does not work as on Linux-native.