### PR TITLE
Correctly mark `Log::Error` as `[[noreturn]]`

### DIFF
--- a/LoKI-B/Log.h
+++ b/LoKI-B/Log.h
@@ -56,7 +56,7 @@ class Log
     }
 
     template <typename... T>
-    inline static void Error(const T &... message)
+    inline static void Error [[noreturn]] (const T &... message)
     {
         std::cerr << RED << "[Error] ";
         ErrorType::print(message...);


### PR DESCRIPTION
As the `Error` function always throws.