### PR TITLE
Make shapeFactor a double instead of a uint8_t

### DIFF
--- a/LoKI-B/ElectronKinetics.h
+++ b/LoKI-B/ElectronKinetics.h
@@ -274,7 +274,7 @@ private:
     /** The parameter that controls the shape of the eedf (1 Maxwellian,
      *  2 Druyvesteyn)
      */
-    const uint8_t shapeParameter;
+    const double shapeParameter;
 };
 
 } // namespace loki

--- a/LoKI-B/Setup.h
+++ b/LoKI-B/Setup.h
@@ -243,7 +243,7 @@ struct lokib_export ElectronKineticsSetup : public SetupBase
 {
     bool isOn{false};
     EedfType eedfType;
-    uint8_t shapeParameter{0};
+    double shapeParameter{0};
     IonizationOperatorType ionizationOperatorType;
     GrowthModelType growthModelType;
     bool includeEECollisions{false};

--- a/source/ElectronKinetics.cpp
+++ b/source/ElectronKinetics.cpp
@@ -1361,7 +1361,7 @@ ElectronKineticsPrescribed::ElectronKineticsPrescribed(const std::filesystem::pa
 
 ElectronKineticsPrescribed::ElectronKineticsPrescribed(const std::filesystem::path &basePath,const json_type &cnf, WorkingConditions *workingConditions)
 : ElectronKinetics(basePath,cnf,workingConditions),
-  shapeParameter(cnf.at("shapeParameter").get<unsigned>())
+  shapeParameter(cnf.at("shapeParameter").get<double>())
 {
     if (getIonizationOperatorType(cnf.at("ionizationOperatorType")) != IonizationOperatorType::conservative)
     {


### PR DESCRIPTION
In C++, a uint8_t is usually handled as an unsigned char. That means that extracting such value from a stream will give unexpected results: if the stream contains "1", the *character* '1' will be extracted, which has numberical value 49. When converting to a double (as happened in the code), 49 is used as value instead of 1 for the shapeParameter. This popped up while working on and testing the prescribed(Eedf) type.

As an example, compile and run the following C++ file:

    #include <cstdint>
    #include <iostream>
    #include <sstream>

    int main()
    {
        std::stringstream ss; ss << "1";
        uint8_t shapeParameter;
        ss >> shapeParameter;
        const double d = shapeParameter;
        std::cout << shapeParameter << std::endl;
        std::cout << d << std::endl;
        return 0;
    }

This will print 1 49, the *character* 1 and its ASCII value 49.