### PR TITLE
Support scientific notation for threshold energies (legacy input)

### DIFF
--- a/source/EedfCollisions.cpp
+++ b/source/EedfCollisions.cpp
@@ -727,7 +727,7 @@ void EedfCollisionDataMixture::loadCollisionsClassic(const std::filesystem::path
     std::ifstream in(file);
     if (!in.is_open())
     {
-        Log<FileError>::Warning(file.generic_string());
+        Log<FileError>::Error(file.generic_string());
         return;
     }
 


### PR DESCRIPTION
See issue #106. Before this patch, "PARAM.:  E = 3e-1 eV" would not be matched; the threshold would be ignored. Instead of 3e-1, one would have to write 0.3. This patch changes the regular expression to match floats 3e-1 as well. I consider this code still very fragile, and we should prevent that misspelled PARAM.: clauses are ignored. After "PARAM.: E = " we should insist that this is followed by "<double> eV", for example.