### PR TITLE
Remove duplicate keys from default_lokib_setup.json

### DIFF
--- a/input/default_lokib_setup.json
+++ b/input/default_lokib_setup.json
@@ -2,11 +2,6 @@
   "workingConditions": {
     "reducedField": 50,
     "_reducedField": "linspace(50,100,6)",
-    "_reducedField": { "value": 50 },
-    "_reducedField": ["linspace", 50, 100, 6],
-    "_reducedField": {
-      "range": { "function": "linspace", "min": 50, "max": 100, "steps": 6 }
-    },
     "electronTemperature": 0.03,
     "excitationFrequency": 0,
     "gasPressure": 133.32,


### PR DESCRIPTION
This file contained multiple "_reducedField" keys --- undefined. This frustrated the parser.