### PR TITLE
Run the `coverage` workflow when PR is ready for review

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [ opened, reopened, synchronize, ready_for_review ]
 
 jobs:
   Test:


### PR DESCRIPTION
Previously, the `coverage` workflow would not run on draft PRs, even after marking them as ready.