### PR TITLE
Make energy, stasticalWeight optional, also in JSON.

### DIFF
--- a/source/StateEntry.cpp
+++ b/source/StateEntry.cpp
@@ -1,6 +1,5 @@
 #include "LoKI-B/StateEntry.h"
 #include "LoKI-B/Log.h"
-#include "LoKI-B/StandardPaths.h"
 #include <fstream>
 #include <regex>
 #include <stdexcept>


### PR DESCRIPTION
Re-apply to the fix of (part of) issue #12; it got lost when moving to JSON internally. The 'energy' and 'statisticalWeight' state property sections are optional (but 'population is still mandatory).