### PR TITLE
invertMatrix: Optionally avoid double normalization

### DIFF
--- a/source/ElectronKinetics.cpp
+++ b/source/ElectronKinetics.cpp
@@ -262,7 +262,7 @@ void ElectronKineticsBoltzmann::invertMatrix(Matrix &matrix)
 #ifdef LOKIB_TIME_INVERT_MATRIX
     auto begin = std::chrono::high_resolution_clock::now();
 #endif
-    /* In this function we use use the matrix, the grid and the eedf vector.
+    /* In this function we use the matrix, the grid and the eedf vector.
      * First check that the dimensions of these variables are OK.
      */
     if (matrix.rows()!=matrix.cols())
@@ -298,10 +298,10 @@ void ElectronKineticsBoltzmann::invertMatrix(Matrix &matrix)
 #if LOKIB_AVOID_NORMALIZING_TWICE
 
         /* replace the first equation with M(1,1)*eedf[0] = M(1,1). After solving
-         * the system, eedf is rescaled as to satisfy the normalization condition.
-         * Choosing M(1,1) is semi-arbitrary, but avoids that we unnecessarily
-         * increase the dynamic range of the matrix elements. In principle any
-         * other non-zero value will do.
+         * the system, the eedf is rescaled as to satisfy the normalization 
+         * condition. Choosing M(1,1) is semi-arbitrary, but avoids that we 
+         * unnecessarily increase the dynamic range of the matrix elements. In 
+         * principle any other non-zero value will do.
          */
         matrix.row(0).setZero();
         matrix(0,0)=matrix(1,1);
@@ -384,7 +384,7 @@ void ElectronKineticsBoltzmann::invertMatrix(Matrix &matrix)
         eedf /= eedf.dot(grid().getCells().cwiseSqrt().cwiseProduct(grid().duCells()));
     }
 #else
-    /** \todo It seems that the normaization is superfluous, since the normalization condition
+    /** \todo It seems that the normalization is superfluous, since the normalization condition
      *        is already part of the system (first row of A, first element of b). One could
      *        decide to change the first equation into eedf[0] = 1 and do the normalization
      *        afterwards. That prevents a fully populated first row of the system matrix


### PR DESCRIPTION
This is related to issue #7. When LOKIB_AVOID_NORMALIZING_TWICE is defined to 1 instead of 0, the new code paths will be activated. These avoid filling the entire first row of the matrix to impose the normalization condition on the EEDF. Instead, the first equation is replaced with M(0,0)*f[0] = M(0,0) (so f[0]=1), and normalization is done afterwards. We set M(0,0) equal to M(1,1) to avoid increasing the dynamic range of the matrix elements.

The patch also adds sanity checking of grid(), eedf and matrix.

More testing is appreciated. Note that small differences can be expected due to the finite machine accuracy. In the mean time we could consider to merge this (with `#define LOKIB_AVOID_NORMALIZING_TWICE 0`) to facilitate such testing.

This patch will be even more advantageous if we start using a band matrix for representing the Boltzmann matrix. (Eigen does not have full band matrix support at present.)