### PR TITLE
Add solver TDMA for tridiagonal systems.

### DIFF
--- a/LoKI-B/LinearAlgebra.h
+++ b/LoKI-B/LinearAlgebra.h
@@ -205,6 +205,41 @@ double *hessenberg(const double *A, double *b, uint32_t n);
  */
 double *hessenberg(const double *A, double *b, uint32_t n, HessenbergWorkspace& hws);
 
+/** The TDMA (Tri-Diagonal Matrix Algorithm) or 'Thomas algorithm' solves a
+ *  system Ax=b for a tridiagonal matrix A. For an explanation, see for example
+ *  https://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm
+ *
+ *  Since non-zero entries of A appear only on the diagonal and the first
+ *  subdiagonal and superdiagonal, the i'th equation takes the form
+    \verbatim
+      i=0:                       A(i,i)x(i) + A(i,i+1)x(i) = b(i),
+      0<i<n-1: A(i,i-1)*x(i-1) + A(i,i)x(i) + A(i,i+1)x(i) = b(i),
+      i=n-1:   A(i,i-1)*x(i-1) + A(i,i)x(i)                = b(i). \endverbatim
+ *
+ *  Other elements of \a A are ignored: on return, \a x will be the solution of
+ *  Ax=b only if A is indeed tridiaogonal. That must be ensured by the caller.
+ *  If the matrix is singular, a runtime_error will be thrown.
+ *
+ *  \author Jan van Dijk
+ *  \date   25 May 2024
+ */
+void solveTDMA(const Matrix& A, const Vector& b, Vector& x);
+
+/** Solve Ax=b for a tridiagonal matrix A.
+ *  This overload of solveTDMA expects that on entry the argument \a bx contains
+ *  the right-hand side b. On return, this has been overwritten by the solution
+ *  vector x. See the three-argument overload for more information.
+ *
+ *  This function calls the three-argument overload by passing \a bx for both
+ *  x and b. That is possible because the algorithm consists of two parts: b is
+ *  used only in the first part, to obtain the values of an auxiliary vector,
+ *  x is calculated in the second part, that no longer depends on b.
+ *
+ *  \author Jan van Dijk
+ *  \date   25 May 2024
+ */
+void solveTDMA(const Matrix& A, Vector& bx);
+
 } // namespace LinAlg
 } // namespace loki
 

--- a/tests/test_linalg.cpp
+++ b/tests/test_linalg.cpp
@@ -8,8 +8,11 @@
 #include "LoKI-B/LinearAlgebra.h"
 #include "tests/TestUtilities.h"
 #include <algorithm>
+#include <chrono>
+#include <limits>
 
 using Matrix = loki::Matrix;
+using Vector = loki::Vector;
 
 void doTestBandwidth(Matrix::Index exp_min, Matrix::Index exp_max, const Matrix& m)
 {
@@ -30,9 +33,72 @@ void testBandwidth()
     doTestBandwidth( -1, -1, (Matrix(2,3) << 0.0, 0.0, 0.0, 1.0, 0.0, 0.0).finished() );
 }
 
+void solveLU(const Matrix& A, const Vector& b, Vector& x)
+{
+    x = A.partialPivLu().solve(b);
+}
+
+void solveHessenberg(const Matrix& A, const Vector& b, Vector& x)
+{
+    x = b;
+    loki::LinAlg::hessenberg(A.data(),x.data(),x.size());
+}
+
+void solveTDMA(const Matrix& A, const Vector& b, Vector& x)
+{
+    loki::LinAlg::solveTDMA(A,b,x);
+}
+
+void solveMatrix(const Matrix& A, const Vector& b, Vector& x, const Vector& x_anal, const std::string& name, void(*solver)(const Matrix&, const Vector&, Vector&))
+{
+    using namespace std::chrono;
+    auto begin = high_resolution_clock::now();
+    (*solver)(A,b,x);
+    auto end = high_resolution_clock::now();
+    std::cout << "Name: " << name << ", duration: " << duration_cast<microseconds>(end - begin).count() << "mus" << std::endl;
+    test_expr((x-x_anal).cwiseQuotient(x_anal).cwiseAbs().sum()/x.size()<100*x.size()*std::numeric_limits<double>::epsilon());
+}
+
+/** Set up, test and benchmark solving a tridiagonal system (a diffusion
+ *  equation) with the available solvers.
+ */
+void testSolversTridiagonal(Matrix::Index n)
+{
+    /* set up a diffusion equation with diffusion coefficient 1, subject to
+     * boundary conditions x(0)=1, x(1)=2. The analytical solution is given
+     * by x_anal(c)=1+c.
+     */
+    const double dx = 1.0/(n-1);
+    Vector x_anal(n);
+    for (Matrix::Index i=0; i!=n; ++i)
+    {
+        x_anal[i] = 1.0+i*dx;
+    }
+    Matrix A(n,n);
+    A.setZero();
+    A.diagonal(-1).fill(-1.0/dx/dx);
+    A.diagonal( 0).fill(+2.0/dx/dx);
+    A.diagonal(+1).fill(-1.0/dx/dx);
+    Vector b(n);
+    b.setZero();
+    A(0,0)=1.0/dx/dx;
+    A(0,1)=0.0;
+    b(0)=1/dx/dx;
+    A(n-1,n-1)=1.0/dx/dx;
+    A(n-1,n-2)=0.0;
+    b(n-1)=2.0/dx/dx;
+
+    Vector x(n);
+    x.setZero();
+    solveMatrix(A,b,x,x_anal,"LU",&solveLU);
+    solveMatrix(A,b,x,x_anal,"Hessenberg",&solveHessenberg);
+    solveMatrix(A,b,x,x_anal,"TDMA",&solveTDMA);
+}
+
 int main()
 {
     testBandwidth();
+    testSolversTridiagonal(10001);
 
     test_report;
 


### PR DESCRIPTION
This is interesting for systems that are known to be tridiagonal, since this is only O(n). Added tests as well. Some numbers for a diffusion equation without sources that is solved for n=10001:
```
  Name: LU, duration:         1187469mus
  Name: Hessenberg, duration:   66277mus
  Name: TDMA, duration:            96mus
```