### PR TITLE
Throw an error when a duplicate process is encountered

### DIFF
--- a/source/EedfCollisions.cpp
+++ b/source/EedfCollisions.cpp
@@ -757,7 +757,6 @@ EedfCollision *EedfCollisionDataMixture::addCollision(CollisionType type, const 
             Log<DoubleCollision>::Warning(*c.m_coll);
 #else
             Log<DoubleCollision>::Error(*c.m_coll);
-            return nullptr;
 #endif
         }
     }


### PR DESCRIPTION
The behavior of `ALLOW_DUPLICATE_PROCESSES` is maintained.

Resolves #22