### PR TITLE
Remove all references to `hasSuperelastics`

### DIFF
--- a/LoKI-B/Operators.h
+++ b/LoKI-B/Operators.h
@@ -120,14 +120,6 @@ namespace loki {
          */
         void evaluateInelasticOperators(const Grid& grid, const EedfMixture& mixture);
         Matrix inelasticMatrix;
-        /* NOTE: the following is not a configuration parameter, but the
-         * result of introspection of the reaction lists. The results also depend
-         * on uMax.
-         * \bug It seems that the value is not always reset to false before making
-         *      it conditionally true during introspection. (That is needed when uMax
-         *      changes.)
-         */
-        bool hasSuperelastics;
     };
 
     class ElectronElectronOperator

--- a/source/Operators.cpp
+++ b/source/Operators.cpp
@@ -419,7 +419,6 @@ std::vector<std::tuple<int, double>> getOperatorDistribution(const Grid& grid, d
 }
 
 InelasticOperator::InelasticOperator(const Grid& grid)
-: hasSuperelastics(false)
 {
     inelasticMatrix.setZero(grid.nCells(), grid.nCells());
 }
@@ -428,10 +427,6 @@ void InelasticOperator::evaluateInelasticOperators(const Grid& grid, const EedfM
 {
     const Grid::Index cellNumber = grid.nCells();
     inelasticMatrix.setZero();
-    /** \todo the following line seems to be missing. See the notes in the
-     *  class declaration of this member
-     */
-    // hasSuperelastics = false;
 
     for (const auto &cd : mixture.collision_data().data_per_gas())
     {
@@ -501,9 +496,6 @@ void InelasticOperator::evaluateInelasticOperators(const Grid& grid, const EedfM
 
                         if (productDensity == 0)
                             continue;
-
-                        if (numThreshold != 1)
-                            hasSuperelastics = true;
 
                         if (grid.isUniform())
                         {


### PR DESCRIPTION
Its functionality is no longer required after merging #162.

closes #157