### PR TITLE
Write JSON output to file, not to the console

### DIFF
--- a/app/loki_main.cpp
+++ b/app/loki_main.cpp
@@ -208,7 +208,7 @@ try
               << std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count()
               << "mus" << std::endl;
 
-    // if data wer harvested (also) in JSON form, print the JSON output object to screen.
+    // If data were harvested (also) in JSON form, save the JSON output object to disk.
     if (json_output_data)
     {
         const std::string fname(cnf.at("output").at("JSONFile"));


### PR DESCRIPTION
When JSON output is requested, also require a file to to write to. Before, JSON was only dumped to the console by the `loki` app at the end of a run. It is checked early that this file can be written to to avoid surprises at the end of a lengthy run, when the data are written to this file. Syntax for JSON output:
```
  writeJSON: false|true
  JSONFile: <filename.json>
```