### PR TITLE
Reduce matrix size in solver tests

### DIFF
--- a/tests/test_linalg.cpp
+++ b/tests/test_linalg.cpp
@@ -98,7 +98,7 @@ void testSolversTridiagonal(Matrix::Index n)
 int main()
 {
     testBandwidth();
-    testSolversTridiagonal(10001);
+    testSolversTridiagonal(1001);
 
     test_report;
 


### PR DESCRIPTION
Previously `test_linalg` was very slow, as the matrix size, was set to 10001. This commit reduces this size to 1001, which is plenty to show the differences between the different algorithms.