### PR TITLE
Keep (E/N)^2 out of the fieldOperator tasks.

### DIFF
--- a/LoKI-B/Operators.h
+++ b/LoKI-B/Operators.h
@@ -98,14 +98,15 @@ namespace loki {
     public:
         FieldOperator(const Grid& grid);
         /// updates member g
-        void evaluate(const Grid& grid, const Vector& totalCS, double EoN, double WoN, double CIEff);
+        void evaluate(const Grid& grid, const Vector& totalCS, double WoN, double CIEff);
         /// updates member g, then the field matrix \a mat
-        void evaluate(const Grid& grid, const Vector& totalCS, double EoN, double WoN, double CIEff, SparseMatrix& mat);
+        void evaluate(const Grid& grid, const Vector& totalCS, double WoN, double CIEff, SparseMatrix& mat);
         /** \todo This expression returns the power that is absorbed from the field
          *  in the case that no temporal or spatial growth terms are present. We have
          *  to see where/when to handle the various growth scenarios.
          */
-        void evaluatePower(const Grid& grid, const Vector& eedf, double& power) const;
+        void evaluatePower(const Grid& grid, const Vector& eedf, double EoN, double& power) const;
+    private:
         Vector g;
     };
 

--- a/source/Operators.cpp
+++ b/source/Operators.cpp
@@ -238,23 +238,23 @@ FieldOperator::FieldOperator(const Grid& grid)
 {
 }
 
-void FieldOperator::evaluate(const Grid& grid, const Vector& totalCS, double EoN, double WoN, double CIEff)
+void FieldOperator::evaluate(const Grid& grid, const Vector& totalCS, double WoN, double CIEff)
 {
     assert(g.size()==grid.getNodes().size());
     g[0] = 0.;
     for (Grid::Index i=1; i!= g.size()-1; ++i)
     {
         const double Omega_x = totalCS[i] + CIEff / (SI::gamma*std::sqrt(grid.getNode(i)));
-        g[i] = (EoN * EoN / 3) * grid.getNode(i) /
+        g[i] = (1. / 3) * grid.getNode(i) /
           (Omega_x + ( WoN * WoN / (SI::gamma*SI::gamma)) / (grid.getNode(i)*Omega_x));
     }
     g[g.size() - 1] = 0.;
 }
 
-void FieldOperator::evaluate(const Grid& grid, const Vector& totalCS, double EoN, double WoN, double CIEff, SparseMatrix& mat)
+void FieldOperator::evaluate(const Grid& grid, const Vector& totalCS, double WoN, double CIEff, SparseMatrix& mat)
 {
     // update g
-    evaluate(grid,totalCS,EoN,WoN,CIEff);
+    evaluate(grid,totalCS,WoN,CIEff);
 
     if (grid.isUniform())
     {
@@ -296,10 +296,10 @@ void FieldOperator::evaluate(const Grid& grid, const Vector& totalCS, double EoN
     }
 }
 
-void FieldOperator::evaluatePower(const Grid& grid, const Vector& eedf, double& power) const
+void FieldOperator::evaluatePower(const Grid& grid, const Vector& eedf, double EoN, double& power) const
 {
     const auto n = grid.nCells();
-    power = SI::gamma * eedf.cwiseProduct(g.tail(n) - g.head(n)).sum();
+    power = SI::gamma * eedf.cwiseProduct(g.tail(n) - g.head(n)).sum() * EoN*EoN;
 }
 
 std::array<double, 2> alphaDistribution(double targetCell, double uMin, double uPlus, double frac = 1.)

--- a/tests/test_nonuniform_druyvesteyn.cpp
+++ b/tests/test_nonuniform_druyvesteyn.cpp
@@ -42,8 +42,10 @@ int main()
     SparseMatrix M2(nCells,nCells);
 
     const double CIEff = 0.0;
-    fieldOperator1.evaluate(grid1, fieldCrossSection, eon, won, CIEff, M1);
-    fieldOperator2.evaluate(grid2, fieldCrossSection, eon, won, CIEff, M2);
+    fieldOperator1.evaluate(grid1, fieldCrossSection, won, CIEff, M1);
+    M1 *= eon*eon;
+    fieldOperator2.evaluate(grid2, fieldCrossSection, won, CIEff, M2);
+    M2 *= eon*eon;
 
     ElasticOperator elasticOperator;
     SparseMatrix Melastic1(nCells, nCells);

--- a/tests/test_nonuniform_field.cpp
+++ b/tests/test_nonuniform_field.cpp
@@ -38,8 +38,10 @@ int main()
     SparseMatrix M2(nCells,nCells);
 
     const double CIEff = 0.0;
-    fieldOperator1.evaluate(grid1, fieldCrossSection, eon, won, CIEff, M1);
-    fieldOperator2.evaluate(grid2, fieldCrossSection, eon, won, CIEff, M2);
+    fieldOperator1.evaluate(grid1, fieldCrossSection, won, CIEff, M1);
+    M1 *= eon*eon;
+    fieldOperator2.evaluate(grid2, fieldCrossSection, won, CIEff, M2);
+    M2 *= eon*eon;
     test_expr(M1.isApprox(M2));
 
     Vector eedf1 = Vector::Zero(nCells);


### PR DESCRIPTION
The field operator's discretize member does not require E/N as parameter anymore. The factor (E/N)^2 needs to be applied to the resulting matrix and now needs to passed to evaluatePower(). This follows the MATLAB code, where this change was made to facilitate the time-dependent simulations, where we have E(t).

This also allows the calculation of the mobility from the fieldMatrix, as explained in the cpp_notes.