### PR TITLE
Cleanup tabular output

### DIFF
--- a/source/Output.cpp
+++ b/source/Output.cpp
@@ -318,7 +318,7 @@ void FileOutput::writeLookupTablePower(const Power &power) const
         os << std::setw(column_width) << "PwrAtt(eVm^3s^-1)";
         os << std::setw(column_width) << "PwrGrowth(eVm^3s^-1)";
         os << std::setw(column_width) << "PwrBalance(eVm^3s^-1)";
-        os << std::setw(column_width) << "RelPwrBalance";
+        os << std::setw(column_width) << "RelPwrBalance(%)";
         os << std::endl;
     }
 
@@ -353,7 +353,7 @@ void FileOutput::writeLookupTablePower(const Power &power) const
     os << std::setw(column_width) << power.attachment.forward;
     os << std::setw(column_width) << power.eDensGrowth;
     os << std::setw(column_width) << power.balance;
-    os << std::setw(column_width) << power.relativeBalance*100;
+    os << std::setw(column_width) << power.relativeBalance * 100;
     os << std::endl;
 }
 


### PR DESCRIPTION
Cleans up tabular output code. Removes duplication of persistent formatting flags, removes magic numbers, fixes #223 (column spacing issue), and reverts part of #154 to make the output equivalent to that of the Matlab version.