### PR TITLE
Throw proper error on unknown species when loading state property

### DIFF
--- a/source/GasMixture.cpp
+++ b/source/GasMixture.cpp
@@ -135,7 +135,7 @@ Gas::State::ChildContainer GasMixture::findStates(const StateEntry &entry)
 void GasMixture::loadStatePropertyEntry(const std::string& state_id, const json_type& propEntry,
                                    StatePropertyType propertyType, const WorkingConditions *workingConditions)
 {
-    std::cout << "loadStatePropertyEntry: handling states " << state_id << ":\n" << propEntry.dump(2) << std::endl;
+    Log<Message>::Notify("loadStatePropertyEntry: handling states ", state_id, ":\n", propEntry.dump(2));
     // 1. Find the state(s) for which the property must be set.
     const StateEntry entry = propertyStateFromString(state_id);
     /** \todo Should this be part of propertyStateFromString?


### PR DESCRIPTION
Previously the call to the `std::runtime_error` constructor would try to access the `state` key on the `propEntry` JSON object. This key does not generally exist on this object, which would in turn throw a different error. This lead to unclear feedback to the user. The problem is fixed by using the available `state_id` instead.

@KevinVeer can you check that this indeed solves the problem you introduced in issue #211?

Resolves #211