### PR TITLE
Issue a warning when the mean electron energy is negative.

### DIFF
--- a/source/ElectronKinetics.cpp
+++ b/source/ElectronKinetics.cpp
@@ -1290,7 +1290,7 @@ void ElectronKineticsBoltzmann::evaluateSwarmParameters()
     {
         Log<Message>::Warning("Negative mean electron energy ", swarmParameters.meanEnergy,
                               "eV encountered at E/N = ", m_workingConditions->reducedField(),
-                              "Td. Make sure to correctly configure the grid and maximum energy.");
+                              "Td. Make sure to use an appropriate grid resolution and maximum energy.");
     }
 
     swarmParameters.characEnergy = swarmParameters.redDiffCoeff / swarmParameters.redMobCoeff;


### PR DESCRIPTION
@KevinVeer does this solve your issue in #209? Using the provided input file with `u_max = 100` and `n_cells = 1000` I get the following new warnings:

```
[Warning] Negative mean electron energy -0.135039eV encountered at E/N = 0.001Td. Make sure to correctly configure the grid and maximum energy.
[Warning] Negative mean electron energy -0.169754eV encountered at E/N = 0.00114976Td. Make sure to correctly configure the grid and maximum energy.
[Warning] Negative mean electron energy -0.197851eV encountered at E/N = 0.00132194Td. Make sure to correctly configure the grid and maximum energy.
[Warning] Negative mean electron energy -0.203839eV encountered at E/N = 0.00151991Td. Make sure to correctly configure the grid and maximum energy.
[Warning] Negative mean electron energy -0.174548eV encountered at E/N = 0.00174753Td. Make sure to correctly configure the grid and maximum energy.
[Warning] Negative mean electron energy -0.113245eV encountered at E/N = 0.00200923Td. Make sure to correctly configure the grid and maximum energy.
[Warning] Negative mean electron energy -0.0387213eV encountered at E/N = 0.00231013Td. Make sure to correctly configure the grid and maximum energy.
```

If you have any suggestions on how to improve the warning message, please let me know!

Resolves #209 