### PR TITLE
Also iterate charge states when checking for elastic cross sections

### DIFF
--- a/source/EedfCollisions.cpp
+++ b/source/EedfCollisions.cpp
@@ -776,9 +776,12 @@ std::vector<const EedfCollisionDataGas::State *> EedfCollisionDataGas::findState
         return true;
     };
 
-    for (const auto *child : m_gas.get_root().children()) {
-        if (child->population() > 0 && !hasElasticRecursive(child)) {
-            statesToUpdate.emplace_back(child);
+    for (const auto *charge_state : m_gas.get_root().children()) {
+        if (charge_state->population() > 0 && !hasElasticRecursive(charge_state)) {
+            for (const auto *e_state : charge_state->children()) {
+                if (e_state->population() > 0 && !hasElasticRecursive(e_state))
+                    statesToUpdate.emplace_back(e_state);
+            }
         }
     }
 


### PR DESCRIPTION
Previously, only the electronic, vibrational, and rotational states were checked in `findStatesToUpdate`. This patch starts the check at the root state instead. This means that a user can now apply an elastic cross section to a charge state, or even a root state.

Note that when an elastic cross section is applied to a charge state, the charge state needs to be present in the `states` section of the LXCat 3 file. The input file presented in #252 can be fixed by moving the elastic collision to the charge level, and adding the neutral charge state: [ArShower_LoKI-B.json](https://github.com/user-attachments/files/21983736/ArShower_LoKI-B.json).


Resolves #252