### PR TITLE
Change standard output path base from `Output` to `output`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# loki-b text-based output
+output/
+
 # Clion specific
 cmake-build-*/
 .idea/

--- a/LoKI-B/StandardPaths.h
+++ b/LoKI-B/StandardPaths.h
@@ -30,8 +30,6 @@
 #ifndef LOKI_CPP_STANDARDPATHS_H
 #define LOKI_CPP_STANDARDPATHS_H
 
-#include <string>
-
-#define LOKIB_OUTPUT_DIR "Output"
+#define LOKIB_OUTPUT_DIR "output"
 
 #endif // LOKI_CPP_STANDARDPATHS_H


### PR DESCRIPTION
To be more in line with the naming convention of the other folders. The path is also added to the .gitignore.