### PR TITLE
Create and use a loki_cpp::loki-b ALIAS target

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,13 +1,13 @@
 add_executable(loki_gasproperties loki_gasproperties.cpp)
-target_link_libraries(loki_gasproperties PRIVATE loki-b)
+target_link_libraries(loki_gasproperties PRIVATE loki_cpp::loki-b)
 
 add_executable(loki_legacytojson loki_legacytojson.cpp)
-target_link_libraries(loki_legacytojson PRIVATE loki-b)
+target_link_libraries(loki_legacytojson PRIVATE loki_cpp::loki-b)
 
 add_executable(loki loki_main.cpp)
-target_link_libraries(loki PRIVATE loki-b)
+target_link_libraries(loki PRIVATE loki_cpp::loki-b)
 
 add_executable(loki_offsidetojson loki_offsidetojson.cpp)
-target_link_libraries(loki_offsidetojson PRIVATE loki-b)
+target_link_libraries(loki_offsidetojson PRIVATE loki_cpp::loki-b)
 
 install(TARGETS loki loki_legacytojson loki_offsidetojson)

--- a/ideas/CMakeLists.txt
+++ b/ideas/CMakeLists.txt
@@ -1,7 +1,7 @@
 enable_testing()
 
-#This custom target_add_test function also handles target relocation 
-#by the CMAKE_RUNTIME_OUTPUT_DIRECTORY directive. see also: 
+#This custom target_add_test function also handles target relocation
+#by the CMAKE_RUNTIME_OUTPUT_DIRECTORY directive. see also:
 #https://stackoverflow.com/questions/21394768/cmake-cannot-find-test-if-cmake-runtime-output-directory-is-changed
 function (target_add_test target)
   add_test (NAME ${target} COMMAND $<TARGET_FILE:${target}>)
@@ -15,14 +15,14 @@ else()
 endif()
 
 add_executable(loki_steps loki_steps.cpp)
-target_link_libraries(loki_steps PRIVATE loki-b)
+target_link_libraries(loki_steps PRIVATE loki_cpp::loki-b)
 
 add_executable(loki_test_statecontainer test_statecontainer.cpp)
-target_link_libraries(loki_test_statecontainer PRIVATE loki-b)
+target_link_libraries(loki_test_statecontainer PRIVATE loki_cpp::loki-b)
 target_add_test(loki_test_statecontainer)
 
 add_executable(loki_example_hessenberg_extra example_hessenberg_extra.cpp HessenbergExtra.cpp)
-target_link_libraries(loki_example_hessenberg_extra PRIVATE loki-b)
+target_link_libraries(loki_example_hessenberg_extra PRIVATE loki_cpp::loki-b)
 
 add_executable(loki_example_cd_discretizer example_cd_discretizer.cpp)
-target_link_libraries(loki_example_cd_discretizer PRIVATE loki-b)
+target_link_libraries(loki_example_cd_discretizer PRIVATE loki_cpp::loki-b)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -30,13 +30,13 @@ target_sources(loki-b PRIVATE
 
 target_include_directories(loki-b  PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:.>  
+  $<INSTALL_INTERFACE:.>
 )
 
 target_compile_definitions(loki-b PUBLIC LOKIB_BUILDING_LIBLOKIB)
 
 if(LOKIB_USE_BUILTIN_NLOHMANN_JSON)
-  target_include_directories(loki-b PUBLIC 
+  target_include_directories(loki-b PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/nlohmann-3.7.0>
   )
 else()
@@ -44,7 +44,7 @@ else()
 endif()
 
 if(LOKIB_USE_BUILTIN_EIGEN)
-  target_include_directories(loki-b PUBLIC 
+  target_include_directories(loki-b PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/eigen-3.4.0>
   )
 else()
@@ -53,7 +53,7 @@ endif()
 
 if(LOKIB_USE_MKL)
   target_link_libraries(loki-b PUBLIC MKL::MKL)
-  target_compile_definitions(loki-b PUBLIC EIGEN_USE_MKL_ALL)  
+  target_compile_definitions(loki-b PUBLIC EIGEN_USE_MKL_ALL)
 endif()
 
 if(LOKIB_USE_OPENBLAS)
@@ -61,7 +61,7 @@ if(LOKIB_USE_OPENBLAS)
   #may be replaced with a more prefered:
   #target_link_libaries(loki-b INTERFACE BLAS::BLAS LAPACK::LAPACK)
   target_link_libraries(loki-b PUBLIC ${LAPACK_LINKER_FLAGS} ${BLAS_LIBRARIES}   )
-  target_link_options(loki-b  PUBLIC ${LAPACK_LINKER_FLAGS} ${BLAS_LINKER_FLAGS})  
+  target_link_options(loki-b  PUBLIC ${LAPACK_LINKER_FLAGS} ${BLAS_LINKER_FLAGS})
   target_compile_definitions(loki-b  PUBLIC EIGEN_USE_LAPACKE EIGEN_USE_BLAS)
 endif()
 
@@ -75,6 +75,8 @@ if(LOKIB_USE_HDF5)
         target_link_libraries(loki-b PUBLIC HighFive)
 endif()
 
+#Create alias for the loki-b target. This is the preferred target to link against
+add_library(loki_cpp::loki-b ALIAS loki-b)
 
 install(
    TARGETS loki-b

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
-#This custom target_add_test function also handles target relocation 
-#by the CMAKE_RUNTIME_OUTPUT_DIRECTORY directive. see also: 
+#This custom target_add_test function also handles target relocation
+#by the CMAKE_RUNTIME_OUTPUT_DIRECTORY directive. see also:
 #https://stackoverflow.com/questions/21394768/cmake-cannot-find-test-if-cmake-runtime-output-directory-is-changed
 function (target_add_test target)
   add_test (NAME ${target} COMMAND $<TARGET_FILE:${target}>)
@@ -22,94 +22,94 @@ if(LOKIB_COVERAGE)
 endif()
 
 add_executable(bolsig_extract bolsig_extract.cpp)
-target_link_libraries(bolsig_extract PRIVATE loki-b)
+target_link_libraries(bolsig_extract PRIVATE loki_cpp::loki-b)
 
 add_executable(compare_tables compare_tables.cpp)
-target_link_libraries(compare_tables PRIVATE loki-b)
+target_link_libraries(compare_tables PRIVATE loki_cpp::loki-b)
 
 add_executable(loki_test_derivatives test_derivatives.cpp)
-target_link_libraries(loki_test_derivatives PRIVATE loki-b)
+target_link_libraries(loki_test_derivatives PRIVATE loki_cpp::loki-b)
 
 add_executable(loki_test_eedf_utilities test_eedf_utilities.cpp)
-target_link_libraries(loki_test_eedf_utilities PRIVATE loki-b)
+target_link_libraries(loki_test_eedf_utilities PRIVATE loki_cpp::loki-b)
 
 add_executable(loki_test_gas_properties test_gas_properties.cpp)
-target_link_libraries(loki_test_gas_properties PRIVATE loki-b)
+target_link_libraries(loki_test_gas_properties PRIVATE loki_cpp::loki-b)
 
 add_executable(loki_test_interpolation test_interpolation.cpp)
-target_link_libraries(loki_test_interpolation PRIVATE loki-b)
+target_link_libraries(loki_test_interpolation PRIVATE loki_cpp::loki-b)
 
 add_executable(loki_test_offside_to_json test_offside_to_json.cpp)
-target_link_libraries(loki_test_offside_to_json PRIVATE loki-b)
+target_link_libraries(loki_test_offside_to_json PRIVATE loki_cpp::loki-b)
 
 add_executable(test_druyvesteyn test_druyvesteyn.cpp)
-target_link_libraries(test_druyvesteyn PRIVATE loki-b)
+target_link_libraries(test_druyvesteyn PRIVATE loki_cpp::loki-b)
 
 add_executable(test_ee test_ee.cpp)
-target_link_libraries(test_ee PRIVATE loki-b)
+target_link_libraries(test_ee PRIVATE loki_cpp::loki-b)
 
 add_executable(test_ee_relaxation test_ee_relaxation.cpp)
-target_link_libraries(test_ee_relaxation PRIVATE loki-b)
+target_link_libraries(test_ee_relaxation PRIVATE loki_cpp::loki-b)
 
 add_executable(test_events test_events.cpp)
-target_link_libraries(test_events PRIVATE loki-b)
+target_link_libraries(test_events PRIVATE loki_cpp::loki-b)
 
 add_executable(test_grid test_grid.cpp)
-target_link_libraries(test_grid PRIVATE loki-b)
+target_link_libraries(test_grid PRIVATE loki_cpp::loki-b)
 
 add_executable(loki_test_integrals test_integrals.cpp)
-target_link_libraries(loki_test_integrals PRIVATE loki-b)
+target_link_libraries(loki_test_integrals PRIVATE loki_cpp::loki-b)
 
 add_executable(test_linalg test_linalg.cpp)
-target_link_libraries(test_linalg PRIVATE loki-b)
+target_link_libraries(test_linalg PRIVATE loki_cpp::loki-b)
 
 add_executable(test_lut test_lut.cpp)
-target_link_libraries(test_lut PRIVATE loki-b)
+target_link_libraries(test_lut PRIVATE loki_cpp::loki-b)
 
 add_executable(test_parser test_parser.cpp)
-target_link_libraries(test_parser PRIVATE loki-b)
+target_link_libraries(test_parser PRIVATE loki_cpp::loki-b)
 
 add_executable(test_json_state_parsing test_json_state_parsing.cpp)
-target_link_libraries(test_json_state_parsing PRIVATE loki-b)
+target_link_libraries(test_json_state_parsing PRIVATE loki_cpp::loki-b)
 
 add_executable(loki_test_range test_range.cpp)
-target_link_libraries(loki_test_range PRIVATE loki-b)
+target_link_libraries(loki_test_range PRIVATE loki_cpp::loki-b)
 
 add_executable(test_reaction_format test_reaction_format.cpp)
-target_link_libraries(test_reaction_format PRIVATE loki-b)
+target_link_libraries(test_reaction_format PRIVATE loki_cpp::loki-b)
 
 add_executable(test_statebase test_statebase.cpp)
-target_link_libraries(test_statebase PRIVATE loki-b)
+target_link_libraries(test_statebase PRIVATE loki_cpp::loki-b)
 
 add_executable(test_trans_coefs test_trans_coefs.cpp)
-target_link_libraries(test_trans_coefs PRIVATE loki-b)
+target_link_libraries(test_trans_coefs PRIVATE loki_cpp::loki-b)
 
 add_executable(test_nonuniform_elastic test_nonuniform_elastic.cpp)
-target_link_libraries(test_nonuniform_elastic PRIVATE loki-b)
+target_link_libraries(test_nonuniform_elastic PRIVATE loki_cpp::loki-b)
 
 add_executable(test_maxwell test_maxwell.cpp)
-target_link_libraries(test_maxwell PRIVATE loki-b)
+target_link_libraries(test_maxwell PRIVATE loki_cpp::loki-b)
 
 add_executable(test_nonuniform_field test_nonuniform_field.cpp)
-target_link_libraries(test_nonuniform_field PRIVATE loki-b)
+target_link_libraries(test_nonuniform_field PRIVATE loki_cpp::loki-b)
 
 add_executable(test_nonuniform_druyvesteyn test_nonuniform_druyvesteyn.cpp)
-target_link_libraries(test_nonuniform_druyvesteyn PRIVATE loki-b)
+target_link_libraries(test_nonuniform_druyvesteyn PRIVATE loki_cpp::loki-b)
 
 add_executable(test_nonuniform_CAR test_nonuniform_CAR.cpp)
-target_link_libraries(test_nonuniform_CAR PRIVATE loki-b)
+target_link_libraries(test_nonuniform_CAR PRIVATE loki_cpp::loki-b)
 
 add_executable(test_nonuniform_inelastic test_nonuniform_inelastic.cpp)
-target_link_libraries(test_nonuniform_inelastic PRIVATE loki-b)
+target_link_libraries(test_nonuniform_inelastic PRIVATE loki_cpp::loki-b)
 
 add_executable(test_nonuniform_operator_distribution test_nonuniform_operator_distribution.cpp)
-target_link_libraries(test_nonuniform_operator_distribution PRIVATE loki-b)
+target_link_libraries(test_nonuniform_operator_distribution PRIVATE loki_cpp::loki-b)
 
 add_executable(test_invalid_inputs test_invalid_inputs.cpp)
-target_link_libraries(test_invalid_inputs PRIVATE loki-b)
+target_link_libraries(test_invalid_inputs PRIVATE loki_cpp::loki-b)
 
 add_executable(test_valid_inputs test_valid_inputs.cpp)
-target_link_libraries(test_valid_inputs PRIVATE loki-b)
+target_link_libraries(test_valid_inputs PRIVATE loki_cpp::loki-b)
 
 target_add_test(loki_test_offside_to_json)
 target_add_test(loki_test_derivatives)
@@ -146,8 +146,8 @@ target_add_test(test_valid_inputs)
 
 if (LOKIB_COVERAGE)
   setup_target_for_coverage_gcovr_xml(
-    NAME coverage 
-    EXECUTABLE ctest --test-dir tests 
+    NAME coverage
+    EXECUTABLE ctest --test-dir tests
     BASE_DIRECTORY "${PROJECT_SOURCE_DIR}"
     DEPENDENCIES ${LOKIB_COVERAGE_TESTS}
   )

--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -3,7 +3,7 @@ message(STATUS "Compiling to WebAssembly.")
 add_executable(loki_bindings bindings.cpp)
 
 target_include_directories(loki_bindings PRIVATE loki-b /usr/lib/emscripten/system/include)
-target_link_libraries(loki_bindings PRIVATE loki-b)
+target_link_libraries(loki_bindings PRIVATE loki_cpp::loki-b)
 
 set_target_properties(loki_bindings PROPERTIES LINK_FLAGS "\
   -s ASSERTIONS=1 \
@@ -27,8 +27,8 @@ set_target_properties(loki_bindings PROPERTIES LINK_FLAGS "\
 # FIXME: The generated files should be placed in `web/wasm`. However, this is
 # currently not possible due to a bug in emscripten
 # (https://github.com/emscripten-core/emscripten/issues/16240).
-set_target_properties(loki_bindings 
-  PROPERTIES 
+set_target_properties(loki_bindings
+  PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/web"
   LIBRARY_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/web"
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/web"


### PR DESCRIPTION
This has a few advantages:

1)  It unifies the experience when using LoKI-B as a subdirectory,  and when using an installed LoKI-B. 
I.e. after running either:

```cmake
  add_subdirectory(LoKI-B)
  find_package(loki-b)
```

you can now do:

```cmake
  target_link_libraries(my_app PRIVATE loki_cpp::loki-b)
```

2) CMake checks at configure time the existence of namespaced libraries. Think of a typo like this:

```cmake
  target_link_libraries(my_app PRIVATE lokib)    #link error!
  target_link_libraries(my_app PRIVATE loki-b)   #Correct
```

 This would only be caught at link time, whereas this would be caught earlier, at configure time (by cmake):

```cmake
  target_link_libraries(my_app PRIVATE loki_cpp::lokib)  #CMake Error!
  target_link_libraries(my_app PRIVATE loki_cpp::loki-b) #Ok
```