### PR TITLE
Use /** \todo ... */ consistently.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,7 +304,7 @@ if(with-hdf5)
         # "H5Oget_info_vers" is not defined, evaluates to 0 [-Werror=undef]
         #       if (H5Oget_info_vers < 3)
         #
-	#TODO: create issue on the HighFive Github page
+	# TODO: create issue on the HighFive Github page
 	#  target_compile_definitions(HighFive INTERFACE H5Oget_info_vers=3)
     endif()
     #Allow direct dumping of Eigen objects

--- a/ideas/HessenbergExtra.cpp
+++ b/ideas/HessenbergExtra.cpp
@@ -52,7 +52,7 @@ inline void reduceRowToHess(double *A, const uint32_t a, const uint32_t b, const
     }
 }
 
-/* TODO: [Optional] Update Hessenberg reduction such that it also alters the b vector.
+/** \todo [Optional] Update Hessenberg reduction such that it also alters the b vector.
  *
  * Idea: Use the 'bandgap' between superelastic diagonals to optimize the algorithm.
  *
@@ -148,7 +148,7 @@ inline void hessenbergReductionOptimal(double *A, const uint32_t *c, uint32_t n,
                 }
             }
 
-            // TODO: CHECK BOUNDS
+            /// \todo CHECK BOUNDS
             for (uint32_t j = optRows; j < g[i]; ++j)
             {
                 //                        std::cerr << "optRows: " << optRows << std::endl;

--- a/source/ElectronKinetics.cpp
+++ b/source/ElectronKinetics.cpp
@@ -1298,7 +1298,7 @@ void ElectronKineticsBoltzmann::evaluateSwarmParameters()
 
     swarmParameters.Te = 2. / 3. * swarmParameters.meanEnergy;
 
-    // TODO: is this correct? (simulations after the first will have a different value for Te).
+    /// \todo is this correct? (simulations after the first will have a different value for Te).
     m_workingConditions->updateElectronTemperature(swarmParameters.Te);
 }
 

--- a/source/Grid.cpp
+++ b/source/Grid.cpp
@@ -154,7 +154,7 @@ void Grid::updateMaxEnergy(double uMax)
 
 void Grid::updateMaxEnergyNonuniform(double uMax, const EedfMixture &mixture)
 {
-    // TODO: Build new nonuniform energy grid.
+    /// \todo Build new nonuniform energy grid.
     Log<Message>::Warning("Combining the smart grid feature with a nonuniform grid is not yet handled correctly.");
 
     updateMaxEnergy(uMax);

--- a/source/Operators.cpp
+++ b/source/Operators.cpp
@@ -389,7 +389,7 @@ std::vector<std::tuple<Grid::Index, double>> distributeNCells(const Grid& grid, 
     alpha.push_back(std::make_tuple(targetBegin, alphaMin[0]));
     for (Grid::Index i = targetBegin + 1; i < targetEnd - 1; i++)
     {
-        // TODO: This is the same as `grid.duCell(i) / grid.duCell(origin)`?
+        /// \todo Is this the same as grid.duCell(i) / grid.duCell(origin) ?
         alpha.push_back(std::make_tuple(i, grid.duCell(i)/(grid.getNode(targetEnd - 1) - grid.getNode(targetBegin + 1)) * alphaMiddle));
     }
     alpha.push_back(std::make_tuple(targetEnd - 1, alphaPlus[1]));
@@ -817,8 +817,10 @@ void IonizationOperator::evaluateIonizationOperator(const Grid& grid, const Eedf
                 {
                     for (Grid::Index k = 0; k < grid.nCells(); ++k)
                     {
-                        // Manual_2_2_0 eq. 15. TODO: Note that newborns are
-                        // inserted in the first cell, so at du/2, not at zero.
+                        // Manual_2_2_0 eq. 15.
+                        /** \todo Note that newborns are inserted in the first cell,
+                         *  so at du/2, not at zero.
+                         */
                         if (k < grid.nCells() - numThreshold)
                             ionizationMatrix(k, k + numThreshold) +=
                                 delta * grid.getCell(k + numThreshold) * cellCrossSection[k + numThreshold];

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1,7 +1,5 @@
 /** \file
  *  Unit tests for Parse.h
- *  \todo Add more tests, use a testing framework that can be reused for other
- *  test file as well
  *
  *  \author Jan van Dijk
  *  \date   November 2020

--- a/tests/test_statebase.cpp
+++ b/tests/test_statebase.cpp
@@ -84,7 +84,7 @@ int main()
     // Spaces are stripped
     test_state_string(gasProps, "N2( + , X , v=0 , J=2 )", true, "N2(+,X,v=0,J=2)");
 
-    // TODO: This currently passes, do we want it to fail?
+    /// \todo This currently passes, do we want it to fail?
     test_state_string(gasProps, "N2(v=0)", true, "N2(v=0)"); // produces state type electronic (not vibrational)
 
     // Things that should fail:

--- a/web/bindings.cpp
+++ b/web/bindings.cpp
@@ -36,7 +36,9 @@ int run(std::string file_contents, emscripten::val callback, emscripten::val out
         std::unique_ptr<Simulation> simulation(new Simulation("", cnf));
         std::unique_ptr<Output> output(new JsonOutput(data_out, cnf, &simulation->workingConditions()));
         /** \todo Perhaps the above should be controlled by
-         * cnf.at("output").at("isOn"). \todo Now that JsonOutput works, we have
+         * cnf.at("output").at("isOn").
+         */
+        /** \todo Now that JsonOutput works, we have
          * two ouput mechanisms in place: handleResults and handleJSONOutput. I
          * think we need only one. It may be useful to send
          * intermediate/incremental output to JS, and let that concatenate the


### PR DESCRIPTION
Changed TODO: in C++ code into \todo, and ensure it is behind // or in a /** ... */ block, so doxygen can pick them up and show them on the bugs and todo pages.

See #171