### PR TITLE
Make param SmartGridParameters constant.

### DIFF
--- a/LoKI-B/Grid.h
+++ b/LoKI-B/Grid.h
@@ -129,7 +129,7 @@ class Grid
 
     // construction and destruction:
 
-    Grid(unsigned nCells, double maxEnergy, SmartGridParameters *smartGridParameters = nullptr);
+    Grid(unsigned nCells, double maxEnergy, const SmartGridParameters *smartGridParameters = nullptr);
     /** Construct a nonuniform Grid from the parameters "nodeDistribution"
      * (Vector) and "maxEnergy" (double).
      * "nodeDistribution" contains doubles in the range [0-1] which indicates
@@ -138,14 +138,14 @@ class Grid
      * The physical energy values of the nodes can be calculated by multiplying
      * the maxEnergy and the nodeDistribution function.
      */
-    Grid(const Vector &nodeDistribution, double maxEnergy, SmartGridParameters *smartGridParameters = nullptr);
+    Grid(const Vector &nodeDistribution, double maxEnergy, const SmartGridParameters *smartGridParameters = nullptr);
     /** Construct a Grid from the parameters "maxEnergy" (double)
      *  and "cellNumber" (unsigned) in the json object \a cnf.
      *  When an element "smartGrid" is present, a SmartGridParameters
      *  object will be created, see smartGrid().
      */
     explicit Grid(const json_type &cnf);
-    Grid(const Vector &nodeDistribution, double maxEnergy, bool isUniform, SmartGridParameters *smartGridParameters = nullptr);
+    Grid(const Vector &nodeDistribution, double maxEnergy, bool isUniform, const SmartGridParameters *smartGridParameters = nullptr);
     /// Grids canot be copied.
     Grid(const Grid &other) = delete;
 
@@ -239,7 +239,7 @@ class Grid
     {
       public:
         SmartGridParameters(const json_type &cnf);
-        /// \todo We don't we use a more straighforward type here, like unsigned?
+        /// \todo Why don't we use a more straighforward type here, like unsigned?
         const uint16_t minEedfDecay;
         const uint16_t maxEedfDecay;
         const double updateFactor;

--- a/source/Grid.cpp
+++ b/source/Grid.cpp
@@ -55,7 +55,7 @@ void Grid::SmartGridParameters::checkConfiguration() const
     }
 }
 
-Grid::Grid(unsigned nCells, double maxEnergy, SmartGridParameters *smartGridParameters)
+Grid::Grid(unsigned nCells, double maxEnergy, const SmartGridParameters *smartGridParameters)
    : Grid(Vector::LinSpaced(nCells + 1, 0.0, 1.0), maxEnergy, true)
 {
     if (smartGridParameters != nullptr) {
@@ -63,12 +63,12 @@ Grid::Grid(unsigned nCells, double maxEnergy, SmartGridParameters *smartGridPara
     }
 }
 
-Grid::Grid(const Vector& nodeDistribution, double maxEnergy, SmartGridParameters *smartGridParameters)
+Grid::Grid(const Vector& nodeDistribution, double maxEnergy, const SmartGridParameters *smartGridParameters)
    : Grid(nodeDistribution, maxEnergy, false, smartGridParameters)
 {
 }
 
-Grid::Grid(const Vector& nodeDistribution, double maxEnergy, bool isUniform, SmartGridParameters *smartGridParameters)
+Grid::Grid(const Vector& nodeDistribution, double maxEnergy, bool isUniform, const SmartGridParameters *smartGridParameters)
  : m_nCells(nodeDistribution.size()-1),
    m_du(isUniform ? maxEnergy/(nodeDistribution.size()-1) : 0.0),
    m_nodes(nodeDistribution*maxEnergy),
@@ -112,7 +112,7 @@ Grid Grid::fromConfig(const json_type &cnf)
             nodeDistribution = Eigen::Map<Vector, Eigen::Unaligned>(nodes.data(), nodes.size());
         }
 
-        SmartGridParameters *parameters = nullptr;
+        const SmartGridParameters *parameters = nullptr;
         if (cnf.contains("smartGrid")) {
             parameters = new SmartGridParameters(cnf.at("smartGrid"));
         }


### PR DESCRIPTION
Use pointers to constant SmartGridParameters objects. Because we can. This emphasizes that these objects are not modified by the Grid constructors.