### PR TITLE
Add a test for calculateBandwidth

### DIFF
--- a/LoKI-B/LinearAlgebra.h
+++ b/LoKI-B/LinearAlgebra.h
@@ -79,11 +79,12 @@ double maxRelDiff(const Vector& v1, const Vector& v2);
  *  superdiagonal. The members first and second of the return value of this
  *  function return the (signed) lower and upper bandwidths, which are defined
  *  as the lowest and highest values of d such that diagonal d contains at least
- *  one non-zero element.
+ *  one non-zero element. For the special case of a zero matrix, the lower and
+ *  upper bandwidths are taken to be zero.
  *
  *  As an example, for a diagonal matrix the return value is {0,0}, for a
  *  tridiagonal matrix it is {-1,1}. For an strictly lower triangular matrix
- *  with R rows and C columns we get {-(R-1),01} and for an upper Hessenberg
+ *  with R rows and C columns we get {-(R-1),-1} and for an upper Hessenberg
  *  matrix the return value is {-1,C-1}. These cases have been visualized
  *  below.
   \verbatim
@@ -97,7 +98,7 @@ double maxRelDiff(const Vector& v1, const Vector& v2);
     00XX
   
     000000
-    X00000 {-3,0}
+    X00000 {-3,-1}
     XX0000
     XXX000
   
@@ -111,7 +112,8 @@ double maxRelDiff(const Vector& v1, const Vector& v2);
  *  \author Jan van Dijk
  *  \date   May 2024
  */
-std::pair<Matrix::Index,Matrix::Index> calculateBandwidth(const Matrix& m);
+using Bandwidth = std::pair<Matrix::Index,Matrix::Index>;
+Bandwidth calculateBandwidth(const Matrix& m);
 
 } // namespace loki
 

--- a/doc/notes/cpp_notes.tex
+++ b/doc/notes/cpp_notes.tex
@@ -3665,6 +3665,32 @@ Note that the expression for the source in the BOLSIG+ paper \cite[eq. 29]{Hagel
 erroneously contains a factor 2 instead of 4. This is pointed out in a footnote on page 23
 of \cite{Hagelaar2008}.
 
+\chapter{Normalization}
+
+Consider a constant $f_0=C$ for $0\leq u\leq u_{\mbox{max}}$. The normalization
+condition results in $\int_0^{u_{\mbox{max}}}\sqrt{u}C\dd{u} = \frac{2}{3}u_{\mbox{max}}^{3/2}C=1$,
+or
+\begin{equation}
+	C = (3/2)u_{\mbox{max}}^{-3/2}.
+\end{equation}
+Numerically, the result is
+\begin{equation}
+	\sum\limits_{c=0}^{{\cal N}-1}C_{{\cal N}}\sqrt{u_c}(\Delta u)_c = 1
+	\implies
+	C_{{\cal N}} = \frac{1}{\sum\limits_{c=0}^{{\cal N}-1}\sqrt{u_c}(\Delta u)_c}.
+\end{equation}
+For a uniform grid we have $(\Delta u)_c:=\Delta u = u_{\mbox{max}}/{\cal N}$
+and $u_c = (c+\frachalf)\Delta u$, or
+\begin{equation}
+	C_{{\cal N}} = \frac{{\cal N}^{3/2}(2/3)}{\sum\limits_{c=0}^{{\cal N}-1}\sqrt{c+\frachalf}}(3/2)u_{\mbox{max}}^{-3/2}.
+\end{equation}
+The relative difference is given by
+\begin{equation}
+	\epsilon_{{\cal N}}
+	:= \frac{C_{{\cal N}}-C}{C}
+	= \frac{{\cal N}^{3/2}(2/3)}{\sum\limits_{c=0}^{{\cal N}-1}\sqrt{c+\frachalf}}-1.
+\end{equation}
+
 \chapter{Old Notes on LoKI-B 1.0.0}
 
 This chapter contains comments on the 1.0.0 version of LoKI-B. Some parts of

--- a/source/LinearAlgebra.cpp
+++ b/source/LinearAlgebra.cpp
@@ -67,7 +67,7 @@ double maxRelDiff(const Vector& v1, const Vector& v2)
     return res;
 }
 
-std::pair<Matrix::Index,Matrix::Index> calculateBandwidth(const Matrix& m)
+Bandwidth calculateBandwidth(const Matrix& m)
 {
     /** \todo In principle, this can be optimized, since for each row the
      *  columns that are within bands that are in [min,max] do not need to
@@ -79,6 +79,7 @@ std::pair<Matrix::Index,Matrix::Index> calculateBandwidth(const Matrix& m)
      */
     Matrix::Index min=+std::max(m.rows(),m.cols());
     Matrix::Index max=-std::max(m.rows(),m.cols());
+
     for (Matrix::Index r=0; r!=m.rows(); ++r)
     for (Matrix::Index c=0; c!=m.cols(); ++c)
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,9 @@ target_link_libraries(bolsig_extract PRIVATE loki_cpp::loki-b)
 add_executable(compare_tables compare_tables.cpp)
 target_link_libraries(compare_tables PRIVATE loki_cpp::loki-b)
 
+add_executable(loki_test_bandwidth test_bandwidth.cpp)
+target_link_libraries(loki_test_bandwidth PRIVATE loki_cpp::loki-b)
+
 add_executable(loki_test_derivatives test_derivatives.cpp)
 target_link_libraries(loki_test_derivatives PRIVATE loki_cpp::loki-b)
 
@@ -112,6 +115,7 @@ add_executable(test_valid_inputs test_valid_inputs.cpp)
 target_link_libraries(test_valid_inputs PRIVATE loki_cpp::loki-b)
 
 target_add_test(loki_test_offside_to_json)
+target_add_test(loki_test_bandwidth)
 target_add_test(loki_test_derivatives)
 target_add_test(loki_test_eedf_utilities)
 target_add_test(test_druyvesteyn)

--- a/tests/test_bandwidth.cpp
+++ b/tests/test_bandwidth.cpp
@@ -1,0 +1,77 @@
+#include "LoKI-B/LinearAlgebra.h"
+#include "tests/TestUtilities.h"
+
+void test_diag()
+{
+    loki::Matrix M(4,4);
+    M << 1.0,  0.0,  0.0, 0.0,
+         0.0,  1.0,  0.0, 0.0,
+         0.0,  0.0,  1.0, 0.0,
+         0.0,  0.0,  0.0, 1.0;
+    const loki::Bandwidth bw = loki::calculateBandwidth(M);
+    test_expr(bw.first==0);
+    test_expr(bw.second==0);
+}
+
+void test_tridiag()
+{
+    loki::Matrix M(4,4);
+    M << 1.0,  1.0,  0.0, 0.0,
+         1.0,  1.0,  1.0, 0.0,
+         0.0,  1.0,  1.0, 1.0,
+         0.0,  0.0,  1.0, 1.0;
+    const loki::Bandwidth bw = loki::calculateBandwidth(M);
+    test_expr(bw.first==-1);
+    test_expr(bw.second==1);
+}
+
+void test_sltriangular()
+{
+    loki::Matrix M(4,5);
+    M << 0.0,  0.0,  0.0, 0.0, 0.0,
+         1.0,  0.0,  0.0, 0.0, 0.0,
+         1.0,  1.0,  0.0, 0.0, 0.0,
+         1.0,  1.0,  1.0, 0.0, 0.0;
+    const loki::Bandwidth bw = loki::calculateBandwidth(M);
+    test_expr(bw.first==-3);
+    test_expr(bw.second==-1);
+}
+
+void test_uhessenberg()
+{
+    loki::Matrix M(5,5);
+    M << 1.0,  1.0,  1.0, 1.0, 1.0,
+         1.0,  1.0,  1.0, 1.0, 1.0,
+         0.0,  1.0,  1.0, 1.0, 1.0,
+         0.0,  0.0,  1.0, 1.0, 1.0,
+         0.0,  0.0,  0.0, 1.0, 1.0;
+    const loki::Bandwidth bw = loki::calculateBandwidth(M);
+    test_expr(bw.first==-1);
+    test_expr(bw.second==4);
+}
+
+/* The O matrix is a special case. The lower and upper bandwidths
+ * are equal to +/- max(rows,cols).
+ */
+void test_null()
+{
+    loki::Matrix M(2,3);
+    M << 0.0,  0.0,
+         0.0,  0.0;
+    const loki::Bandwidth bw = loki::calculateBandwidth(M);
+    test_expr(bw.first==+3);
+    test_expr(bw.second==-3);
+}
+
+int main()
+{
+    test_diag();
+    test_tridiag();
+    test_sltriangular();
+    test_uhessenberg();
+    test_null();
+
+    test_report;
+
+    return nerrors;
+}

--- a/tests/test_bandwidth.cpp
+++ b/tests/test_bandwidth.cpp
@@ -56,8 +56,8 @@ void test_uhessenberg()
 void test_null()
 {
     loki::Matrix M(2,3);
-    M << 0.0,  0.0,
-         0.0,  0.0;
+    M << 0.0,  0.0, 0.0,
+         0.0,  0.0, 0.0;
     const loki::Bandwidth bw = loki::calculateBandwidth(M);
     test_expr(bw.first==+3);
     test_expr(bw.second==-3);


### PR DESCRIPTION
Also introduce `Bandwidth` as a `typename` for `std::pair<Matrix::Index,Matrix::Index>`.

NOTE: the semantics are still subject to debate, and we should decide if we want to be compatible with MATLAB or particular C++ libraries. The present pull request just adds tests for the existing behavior.