### PR TITLE
Update dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741600792,
-        "narHash": "sha256-yfDy6chHcM7pXpMF4wycuuV+ILSTG486Z/vLx/Bdi6Y=",
+        "lastModified": 1780203844,
+        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ebe2788eafd539477f83775ef93c3c7e244421d3",
+        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
   };
 
   outputs =
@@ -12,7 +12,7 @@
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
 
-      gccEnv = pkgs.gcc11Stdenv;
+      gccEnv = pkgs.gcc16Stdenv;
 
       latex =
         with pkgs;

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
         cmake
 
         # Dependencies
-        eigen
+        eigen_5
         nlohmann_json
         openblas
 

--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -10,7 +10,7 @@ set_target_properties(loki_bindings PROPERTIES LINK_FLAGS "\
   -s ALLOW_MEMORY_GROWTH=1 \
   -s MODULARIZE=1 \
   -s EXPORT_NAME=create_module \
-  -s EXPORTED_RUNTIME_METHODS=[FS,run] \
+  -s EXPORTED_RUNTIME_METHODS=[HEAPF64,run] \
   -s ENVIRONMENT=web,worker \
   -s NO_DISABLE_EXCEPTION_CATCHING \
   -lembind \


### PR DESCRIPTION
This updates the `nixpkgs` input to follow `26.05`, which results in the following relevant dependency updates:

- `cmake` to `4.1.2`,
- `ninja` to `1.13.2`,
- `gcc` to `16.1.0`,
- `emscripten` to `5.0.6`,
- `eigen` to `5.0.1`,
- `nlohmann_json` to `3.12, and
- `openblas` to `0.3.32`.