### PR TITLE
Fix OpenMP detection on macOS with Homebrew libomp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,25 @@ endif()
 option(LOKIB_USE_OPENMP "Use OpenMP parallelization" ON)
 loki_constrain_configure_option(LOKIB_USE_OPENMP ON OFF)
 if(LOKIB_USE_OPENMP)
+	# Apple Clang does not ship OpenMP; Homebrew's libomp is the usual provider.
+	if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+		execute_process(
+			COMMAND brew --prefix libomp
+			RESULT_VARIABLE _loki_brew_libomp_result
+			OUTPUT_VARIABLE _loki_libomp_prefix
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+			ERROR_QUIET
+		)
+		if(_loki_brew_libomp_result EQUAL 0 AND EXISTS "${_loki_libomp_prefix}/lib/libomp.dylib")
+			message(STATUS "Using Homebrew libomp from ${_loki_libomp_prefix}")
+			set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp -I${_loki_libomp_prefix}/include")
+			set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I${_loki_libomp_prefix}/include")
+			set(OpenMP_C_LIB_NAMES omp)
+			set(OpenMP_CXX_LIB_NAMES omp)
+			set(OpenMP_omp_LIBRARY "${_loki_libomp_prefix}/lib/libomp.dylib")
+		endif()
+	endif()
+
 	find_package(OpenMP)
 	if(NOT OpenMP_CXX_FOUND)
 		message(FATAL_ERROR "OpenMP could not be found. Install the missing OpenMP package(s), or disable OpenMP support with -DLOKIB_USE_OPENMP=OFF")


### PR DESCRIPTION
## Summary
- Detect Homebrew's `libomp` on Apple Clang before running `find_package(OpenMP)`.
- Set the compiler and linker hints (`OpenMP_*_FLAGS`, `OpenMP_omp_LIBRARY`) expected by CMake's `FindOpenMP` module on macOS.

## Motivation
Apple Clang does not ship OpenMP. On macOS, developers typically install OpenMP via Homebrew (`brew install libomp`), but CMake's default OpenMP search fails without explicit prefix/flag hints. This change lets a normal configure succeed when `libomp` is installed through Homebrew.

## Test plan
- [x] Verified locally on macOS (Apple Clang + Homebrew libomp):
  ```bash
  cmake -S . -B build -DLOKIB_USE_OPENMP=ON \
        -DLOKIB_USE_BUILTIN_NLOHMANN_JSON=ON \
        -DLOKIB_USE_BUILTIN_EIGEN=ON
  ```
  Output includes `Using Homebrew libomp from /opt/homebrew/opt/libomp` and `Found OpenMP`.
- [ ] CI Linux/macOS builds pass unchanged for platforms without Homebrew libomp.


Made with [Cursor](https://cursor.com)